### PR TITLE
Add `get_inputs_generator` classmethod to `CommonRelaxWorkChain`

### DIFF
--- a/aiida_common_workflows/workflows/relax/bigdft/__init__.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=undefined-variable
-"""Module with the implementations of the common structure relaxation workchainm for Quantum ESPRESSO."""
+"""Module with the implementations of the common structure relaxation workchain for BigDFT."""
 from .generator import *
+from .workchain import *
 
-__all__ = (generator.__all__)
+__all__ = (generator.__all__ + workchain.__all__)

--- a/aiida_common_workflows/workflows/relax/bigdft/generator.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/generator.py
@@ -3,21 +3,19 @@
 from aiida import orm
 from aiida.plugins import DataFactory
 from ..generator import RelaxInputsGenerator, RelaxType
-from .workchain import BigDFTCommonRelaxWorkChain
 
-__all__ = ('BigDFTRelaxInputsGenerator',)
+__all__ = ('BigDftRelaxInputsGenerator',)
 
 BigDFTParameters = DataFactory('bigdft')
 
 
-class BigDFTRelaxInputsGenerator(RelaxInputsGenerator):
+class BigDftRelaxInputsGenerator(RelaxInputsGenerator):
     """Input generator for the `BigDFTRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
     _protocols = {
         'fast': {
-            'description': 'This profile should be chosen if speed\
- is more important than accuracy.',
+            'description': 'This profile should be chosen if speed is more important than accuracy.',
             'inputdict_cubic': {
                 'dft': {
                     'hgrids': 0.45
@@ -28,17 +26,15 @@ class BigDFTRelaxInputsGenerator(RelaxInputsGenerator):
             }
         },
         'moderate': {
-            'description': 'This profile should be chosen if accurate forces \
-are required, but there is no need for extremely \
-accurate energies.',
+            'description': 'This profile should be chosen if accurate forces are required, but there is no need for '
+            'extremely accurate energies.',
             'inputdict_cubic': {},
             'inputdict_linear': {
                 'import': 'linear'
             }
         },
         'precise': {
-            'description': 'This profile should be chosen if highly accurate\
-                            energy differences are required.',
+            'description': 'This profile should be chosen if highly accurate energy differences are required.',
             'inputdict_cubic': {
                 'dft': {
                     'hgrids': 0.15
@@ -75,11 +71,11 @@ accurate energies.',
         else:
             raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))
 
-        builder = BigDFTCommonRelaxWorkChain.get_builder()
+        builder = self._process_class.get_builder()
         builder.structure = structure
 
-        #Will be implemented in the bigdft plugin
-        #inputdict = BigDFTParameters.get_input_dict(protocol, structure, 'relax')
+        # Will be implemented in the bigdft plugin
+        # inputdict = BigDFTParameters.get_input_dict(protocol, structure, 'relax')
         # for now apply simple stupid heuristic : atoms < 200 -> cubic, else -> linear.
         if len(structure.sites) <= 200:
             inputdict = self.get_protocol(protocol)['inputdict_cubic']

--- a/aiida_common_workflows/workflows/relax/bigdft/workchain.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/workchain.py
@@ -3,22 +3,23 @@
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
+from .generator import BigDftRelaxInputsGenerator
 
-__all__ = ('BigDFTCommonRelaxWorkChain',)
-
-RelaxWorkChain = WorkflowFactory('bigdft.relax')
+__all__ = ('BigDftRelaxWorkChain',)
 
 
-class BigDFTCommonRelaxWorkChain(CommonRelaxWorkChain):
+class BigDftRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for BigDFT."""
 
-    _process_class = RelaxWorkChain
+    _process_class = WorkflowFactory('bigdft.relax')
+    _generator_class = BigDftRelaxInputsGenerator
 
     @classmethod
     def define(cls, spec):
         # yapf: disable
         super().define(spec)
-        spec.expose_outputs(RelaxWorkChain)
+        spec.expose_outputs(cls._process_class)
 
     def convert_outputs(self):
-        self.out_many(self.exposed_outputs(self.ctx.workchain, RelaxWorkChain))
+        """Convert the outputs of the sub workchain to the common output specification."""
+        self.out_many(self.exposed_outputs(self.ctx.workchain, self._process_class))

--- a/aiida_common_workflows/workflows/relax/examples/eos_silicon_vasp.py
+++ b/aiida_common_workflows/workflows/relax/examples/eos_silicon_vasp.py
@@ -6,13 +6,13 @@ from aiida.engine import run
 from aiida.plugins import DataFactory
 
 from aiida_common_workflows.workflows.relax.generator import RelaxType
-from aiida_common_workflows.workflows.relax.vasp import VASPRelaxInputsGenerator
+from aiida_common_workflows.workflows.relax.vasp import VaspRelaxInputsGenerator
 
 load_profile()
 
 StructureData = DataFactory('structure')  # pylint: disable=invalid-name
 
-GENERATOR = VASPRelaxInputsGenerator
+GENERATOR = VaspRelaxInputsGenerator
 CALC_ENGINES = {
     'relax': {
         'code': 'vasp@mycluster',

--- a/aiida_common_workflows/workflows/relax/fleur/__init__.py
+++ b/aiida_common_workflows/workflows/relax/fleur/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=undefined-variable
-"""Module with the implementations of the common structure relaxation workchainm for FLEUR."""
+"""Module with the implementations of the common structure relaxation workchain for FLEUR."""
 from .generator import *
 from .workchain import *
 

--- a/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
-"""
-Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator`
-for FLEUR.
-"""
+"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for FLEUR."""
 from aiida.orm import Dict, Code
 from ..generator import RelaxInputsGenerator, RelaxType
-from .workchain import FleurCRelaxWorkChain as FleurRelaxationWorkChain
 
 __all__ = ('FleurRelaxInputsGenerator',)
 
@@ -57,12 +53,10 @@ class FleurRelaxInputsGenerator(RelaxInputsGenerator):
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
         # pylint: disable=too-many-locals
-        #from aiida_fleur.tools.common_wf_util import generate_scf_inputs
-
         fleur_code = Code.get_from_string(calc_engines['relax']['code'])
         inpgen_code = Code.get_from_string(calc_engines['relax']['inputgen'])
 
-        builder = FleurRelaxationWorkChain.get_builder()
+        builder = self._process_class.get_builder()
 
         # implement this, protocol dependent, we still have option keys as nodes ...
         # has to go over calc parameters, kmax, lmax, kpoint density

--- a/aiida_common_workflows/workflows/relax/fleur/workchain.py
+++ b/aiida_common_workflows/workflows/relax/fleur/workchain.py
@@ -1,17 +1,13 @@
 # -*- coding: utf-8 -*-
-"""
-Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain`
-for FLEUR (www.flapw.de).
-"""
+"""Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for FLEUR (www.flapw.de)."""
 from aiida import orm
 from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
+from .generator import FleurRelaxInputsGenerator
 
-__all__ = ('FleurCRelaxWorkChain',)
-
-AiidaFleurRelaxWorkChain = WorkflowFactory('fleur.base_relax')
+__all__ = ('FleurRelaxWorkChain',)
 
 
 @calcfunction
@@ -31,13 +27,11 @@ def get_total_energy(parameters):
     return orm.Float(parameters.get_attribute('energy'))
 
 
-class FleurCRelaxWorkChain(CommonRelaxWorkChain):
-    """
-    Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain`
-    for FLEUR.
-    """
+class FleurRelaxWorkChain(CommonRelaxWorkChain):
+    """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for FLEUR."""
 
-    _process_class = AiidaFleurRelaxWorkChain
+    _process_class = WorkflowFactory('fleur.base_relax')
+    _generator_class = FleurRelaxInputsGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -24,22 +24,29 @@ class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):
 
     _calc_types = None
     _relax_types = None
+    _process_class = None
 
     def __init__(self, *args, **kwargs):
         """Construct an instance of the inputs generator, validating the class attributes."""
-        super().__init__(*args, **kwargs)
 
         def raise_invalid(message):
             raise RuntimeError('invalid inputs generator `{}`: {}'.format(self.__class__.__name__, message))
 
+        try:
+            self._process_class = kwargs.pop('process_class')
+        except KeyError:
+            raise_invalid('required keyword argument `process_class` was not defined.')
+
+        super().__init__(*args, **kwargs)
+
         if self._calc_types is None:
-            raise_invalid('does not define `_calc_types`')
+            raise_invalid('does not define `_calc_types`.')
 
         if self._relax_types is None:
-            raise_invalid('does not define `_relax_types`')
+            raise_invalid('does not define `_relax_types`.')
 
         if any([not isinstance(relax_type, RelaxType) for relax_type in self._relax_types]):
-            raise_invalid('`_relax_types` are not all instances of RelaxType')
+            raise_invalid('`_relax_types` are not all an instance of `RelaxType`')
 
     @abstractmethod
     def get_builder(

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/__init__.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=undefined-variable
-"""Module with the implementations of the common structure relaxation workchainm for Quantum ESPRESSO."""
+"""Module with the implementations of the common structure relaxation workchain for Quantum ESPRESSO."""
 from .generator import *
 from .workchain import *
 

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -12,7 +12,6 @@ from aiida.common import exceptions
 from aiida_sssp.groups import SsspFamily
 
 from ..generator import RelaxInputsGenerator, RelaxType
-from .workchain import QuantumEspressoRelaxWorkChain
 
 __all__ = ('QuantumEspressoRelaxInputsGenerator',)
 
@@ -36,7 +35,7 @@ class QuantumEspressoRelaxInputsGenerator(RelaxInputsGenerator):
 
     def _initialize_protocols(self):
         """Initialize the protocols class attribute by parsing them from the configuration file."""
-        with open(pathlib.Path(__file__).parent / 'protocol.yml') as handle:
+        with open(str(pathlib.Path(__file__).parent / 'protocol.yml')) as handle:
             self._protocols = yaml.safe_load(handle)
 
     def get_builder(
@@ -63,8 +62,8 @@ class QuantumEspressoRelaxInputsGenerator(RelaxInputsGenerator):
         code = calc_engines['relax']['code']
         override = {'base': {'pw': {'metadata': {'options': calc_engines['relax']['options']}}}}
 
-        builder = QuantumEspressoRelaxWorkChain.get_builder()
-        inputs = generate_inputs(QuantumEspressoRelaxWorkChain._process_class, protocol, code, structure, override)  # pylint: disable=protected-access
+        builder = self._process.get_builder()
+        inputs = generate_inputs(self._process_class, protocol, code, structure, override)  # pylint: disable=protected-access
         builder._update(inputs)  # pylint: disable=protected-access
 
         if relaxation_type == RelaxType.ATOMS:

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/workchain.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/workchain.py
@@ -5,10 +5,9 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
+from .generator import QuantumEspressoRelaxInputsGenerator
 
 __all__ = ('QuantumEspressoRelaxWorkChain',)
-
-PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
 
 
 @calcfunction
@@ -36,7 +35,8 @@ def get_total_energy(parameters):
 class QuantumEspressoRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Quantum ESPRESSO."""
 
-    _process_class = PwRelaxWorkChain
+    _process_class = WorkflowFactory('quantumespresso.pw.relax')
+    _generator_class = QuantumEspressoRelaxInputsGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/siesta/__init__.py
+++ b/aiida_common_workflows/workflows/relax/siesta/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=undefined-variable
-"""Module with the implementations of the common structure relaxation workchainm for Siesta."""
+"""Module with the implementations of the common structure relaxation workchain for Siesta."""
 from .generator import *
 from .workchain import *
 

--- a/aiida_common_workflows/workflows/relax/siesta/workchain.py
+++ b/aiida_common_workflows/workflows/relax/siesta/workchain.py
@@ -1,43 +1,39 @@
 # -*- coding: utf-8 -*-
-"""
-WorkChain that runs SiestaBaseWorkChain of aiida_siesta package and
-returns the agreed outputs.
-"""
-from aiida.orm import (Float, ArrayData)
+"""Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for SIESTA."""
+from aiida import orm
 from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
-from aiida_common_workflows.workflows.relax.workchain import CommonRelaxWorkChain
+
+from ..workchain import CommonRelaxWorkChain
+from .generator import SiestaRelaxInputsGenerator
 
 __all__ = ('SiestaRelaxWorkChain',)
-
-SiestaBaseWorkChain = WorkflowFactory('siesta.base')  #pylint: disable=invalid-name
 
 
 @calcfunction
 def get_energy(pardict):
     """Extract the energy from the `output_parameters` dictionary"""
-    return Float(pardict['E_KS'])
+    return orm.Float(pardict['E_KS'])
 
 
 @calcfunction
 def get_forces_and_stress(totalarray):
     """Separates the forces and stress in two different arrays"""
-    forces = ArrayData()
+    forces = orm.ArrayData()
     forces.set_array(name='forces', array=totalarray.get_array('forces'))
-    stress = ArrayData()
+    stress = orm.ArrayData()
     stress.set_array(name='stress', array=totalarray.get_array('stress'))
     return {'forces': forces, 'stress': stress}
 
 
 class SiestaRelaxWorkChain(CommonRelaxWorkChain):
-    """
-    Workchain to relax a structure through Siesta. The outputs
-    follows some standardization agreed at AiiDA Hackaton of Feb 2020.
-    """
-    _process_class = SiestaBaseWorkChain
+    """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for SIESTA."""
+
+    _process_class = WorkflowFactory('siesta.base')
+    _generator_class = SiestaRelaxInputsGenerator
 
     def convert_outputs(self):
-        """Convert outputs to the agreed standards"""
+        """Convert the outputs of the sub workchain to the common output specification."""
         self.report('Relaxation task concluded sucessfully, converting outputs')
         self.out('relaxed_structure', self.ctx.workchain.outputs.output_structure)
         self.out('total_energy', get_energy(self.ctx.workchain.outputs.output_parameters))

--- a/aiida_common_workflows/workflows/relax/vasp/__init__.py
+++ b/aiida_common_workflows/workflows/relax/vasp/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=undefined-variable
-"""Module with the implementations of the common structure relaxation workchainm for VASP."""
+"""Module with the implementations of the common structure relaxation workchain for VASP."""
 from .generator import *
 from .workchain import *
 

--- a/aiida_common_workflows/workflows/relax/vasp/generator.py
+++ b/aiida_common_workflows/workflows/relax/vasp/generator.py
@@ -8,12 +8,11 @@ from aiida.orm import Code
 from aiida.common.extendeddicts import AttributeDict
 
 from ..generator import RelaxInputsGenerator, RelaxType
-from .workchain import CommonVASPRelaxWorkChain
 
-__all__ = ('VASPRelaxInputsGenerator',)
+__all__ = ('VaspRelaxInputsGenerator',)
 
 
-class VASPRelaxInputsGenerator(RelaxInputsGenerator):
+class VaspRelaxInputsGenerator(RelaxInputsGenerator):
     """Input generator for the `VASPRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
@@ -32,12 +31,12 @@ class VASPRelaxInputsGenerator(RelaxInputsGenerator):
 
     def _initialize_protocols(self):
         """Initialize the protocols class attribute by parsing them from the protocols configuration file."""
-        with open(pathlib.Path(__file__).parent / 'protocols.yml') as handle:
+        with open(str(pathlib.Path(__file__).parent / 'protocols.yml')) as handle:
             self._protocols = yaml.safe_load(handle)
 
     def _initialize_potential_mapping(self):
         """Initialize the potential mapping from the potential_mapping configuration file."""
-        with open(pathlib.Path(__file__).parent / 'potential_mapping.yml') as handle:
+        with open(str(pathlib.Path(__file__).parent / 'potential_mapping.yml')) as handle:
             self._potential_mapping = yaml.safe_load(handle)
 
     def get_builder(
@@ -69,7 +68,7 @@ class VASPRelaxInputsGenerator(RelaxInputsGenerator):
         protocol = self.get_protocol(protocol)
 
         # Set the builder
-        builder = CommonVASPRelaxWorkChain.get_builder()
+        builder = self._process_class.get_builder()
 
         # Set code
         builder.code = Code.get_from_string(calc_engines['relax']['code'])

--- a/aiida_common_workflows/workflows/relax/vasp/workchain.py
+++ b/aiida_common_workflows/workflows/relax/vasp/workchain.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for VASP."""
+from aiida import orm
 from aiida.engine import calcfunction
-from aiida.plugins import WorkflowFactory, DataFactory
+from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
+from .generator import VaspRelaxInputsGenerator
 
-__all__ = ('CommonVASPRelaxWorkChain',)
-
-VASPRelaxWorkChain = WorkflowFactory('vasp.relax')  # pylint: disable=invalid-name
+__all__ = ('VaspRelaxWorkChain',)
 
 
 @calcfunction
 def get_stress(stress):
     """Return the final stress array."""
-    stress_data = DataFactory('array')()
+    stress_data = orm.ArrayData()
     stress_data.set_array(name='stress', array=stress.get_array('final'))
     return stress_data
 
@@ -21,7 +21,7 @@ def get_stress(stress):
 @calcfunction
 def get_forces(forces):
     """Return the final forces array.."""
-    forces_data = DataFactory('array')()
+    forces_data = orm.ArrayData()
     forces_data.set_array(name='forces', array=forces.get_array('final'))
     return forces_data
 
@@ -30,14 +30,15 @@ def get_forces(forces):
 def get_total_energy(misc):
     """Return the total energy from misc."""
     misc_dict = misc.get_dict()
-    total_energy = DataFactory('float')(misc_dict['total_energies']['energy_no_entropy'])
+    total_energy = orm.Float(misc_dict['total_energies']['energy_no_entropy'])
     return total_energy
 
 
-class CommonVASPRelaxWorkChain(CommonRelaxWorkChain):
+class VaspRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for VASP."""
 
-    _process_class = VASPRelaxWorkChain
+    _process_class = WorkflowFactory('vasp.relax')
+    _generator_class = VaspRelaxInputsGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/workchain.py
+++ b/aiida_common_workflows/workflows/relax/workchain.py
@@ -5,6 +5,8 @@ from abc import ABCMeta, abstractmethod
 from aiida.engine import WorkChain, ToContext
 from aiida.orm import StructureData, ArrayData, TrajectoryData, Float
 
+from .generator import RelaxInputsGenerator
+
 __all__ = ('CommonRelaxWorkChain',)
 
 
@@ -17,6 +19,15 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
     """
 
     _process_class = None
+    _generator_class = None
+
+    @classmethod
+    def get_inputs_generator(cls) -> RelaxInputsGenerator:
+        """Return an instance of the inputs generator for this work chain.
+
+        :return: inputs generator
+        """
+        return cls._generator_class(process_class=cls._process_class)  # pylint: disable=not-callable
 
     @classmethod
     def define(cls, spec):

--- a/tests/workflows/relax/quantum_espresso/test_generator.py
+++ b/tests/workflows/relax/quantum_espresso/test_generator.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso.generator` module."""
+import pytest
+
+from aiida.plugins import WorkflowFactory
+from aiida_common_workflows.workflows.relax.quantum_espresso import QuantumEspressoRelaxInputsGenerator
+
+PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
+
+
+def test_construction_fail():
+    """Test that the generator constructor raises if no `process_class` is defined."""
+    with pytest.raises(RuntimeError, match=r'.*required keyword argument `process_class` was not defined.'):
+        QuantumEspressoRelaxInputsGenerator()
+
+
+def test_construction():
+    """Test that the generator can be successfully constructed, meaning class attributes have been correctly defined."""
+    QuantumEspressoRelaxInputsGenerator(process_class=PwRelaxWorkChain)

--- a/tests/workflows/relax/quantum_espresso/test_workchain.py
+++ b/tests/workflows/relax/quantum_espresso/test_workchain.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso.workchain` module."""
+from aiida_common_workflows.workflows.relax.quantum_espresso import QuantumEspressoRelaxWorkChain
+from aiida_common_workflows.workflows.relax.quantum_espresso import QuantumEspressoRelaxInputsGenerator
+
+
+def test_get_inputs_generator():
+    """Test the `get_inputs_generator` class property."""
+    assert isinstance(QuantumEspressoRelaxWorkChain.get_inputs_generator(), QuantumEspressoRelaxInputsGenerator)

--- a/tests/workflows/relax/test_generator.py
+++ b/tests/workflows/relax/test_generator.py
@@ -4,7 +4,7 @@
 import pytest
 
 from aiida_common_workflows.protocol import ProtocolRegistry
-from aiida_common_workflows.workflows.relax import RelaxInputsGenerator, RelaxType
+from aiida_common_workflows.workflows.relax import RelaxInputsGenerator, RelaxType, CommonRelaxWorkChain
 
 
 @pytest.fixture
@@ -37,7 +37,7 @@ def inputs_generator(protocol_registry) -> RelaxInputsGenerator:
         def get_builder(self):
             pass
 
-    return InputsGenerator()
+    return InputsGenerator(process_class=CommonRelaxWorkChain)
 
 
 def test_validation(protocol_registry):
@@ -51,6 +51,7 @@ def test_validation(protocol_registry):
         _calc_types = None
         _relax_types = None
 
+    # Abstract `get_builder` method so should raise `TypeError`
     with pytest.raises(TypeError):
         InputsGenerator()
 
@@ -58,18 +59,6 @@ def test_validation(protocol_registry):
         """Invalid inputs generator implementation."""
 
         _calc_types = {'relax': {}}
-        _relax_types = None
-
-        def get_builder(self):
-            pass
-
-    with pytest.raises(RuntimeError):
-        InputsGenerator()
-
-    class InputsGenerator(protocol_registry, RelaxInputsGenerator):
-        """Invalid inputs generator implementation."""
-
-        _calc_types = None
         _relax_types = {RelaxType.ATOMS: 'description'}
 
         def get_builder(self):
@@ -82,13 +71,37 @@ def test_validation(protocol_registry):
         """Invalid inputs generator implementation."""
 
         _calc_types = {'relax': {}}
+        _relax_types = None
+
+        def get_builder(self):
+            pass
+
+    with pytest.raises(RuntimeError):
+        InputsGenerator(process_class=CommonRelaxWorkChain)
+
+    class InputsGenerator(protocol_registry, RelaxInputsGenerator):
+        """Invalid inputs generator implementation."""
+
+        _calc_types = None
+        _relax_types = {RelaxType.ATOMS: 'description'}
+
+        def get_builder(self):
+            pass
+
+    with pytest.raises(RuntimeError):
+        InputsGenerator(process_class=CommonRelaxWorkChain)
+
+    class InputsGenerator(protocol_registry, RelaxInputsGenerator):
+        """Invalid inputs generator implementation."""
+
+        _calc_types = {'relax': {}}
         _relax_types = {'invalid-type': 'description'}
 
         def get_builder(self):
             pass
 
     with pytest.raises(RuntimeError):
-        InputsGenerator()
+        InputsGenerator(process_class=CommonRelaxWorkChain)
 
 
 def test_get_calc_types(inputs_generator):


### PR DESCRIPTION
This method serves as a proxy to generate an instance of the
`InputsGenerator` that is implemented for the subclass of the common
relax work chain. The work chain sub class should just define the
`_generator_class` class attribute to the subclass of the
`RelaxInputsGenerator`, just like it defines the `_process_class`.

Since the work chain will be the main point of entry for all
interactions, this way any client can obtain an instance of the input
generator which in turn provides all the information about available
protocols and the actual method to generate the inputs.