### PR TITLE
CI: Update `setup-python` action to v2 in order to pin Python to 3.7.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
                     pip-pre-commit-
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -40,7 +40,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8]
+                python-version: [3.5, 3.6, 3.7.7, 3.8]
 
         steps:
         -   uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
                     pip-${{ matrix.python-version }}-tests
 
         -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: ${{ matrix.python-version }}
 

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -28,9 +28,6 @@ class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):
         """Construct an instance of the inputs generator, validating the class attributes."""
         super().__init__(*args, **kwargs)
 
-        def raise_invalid(message):
-            raise RuntimeError('invalid protocol registry `{}`: '.format(self.__class__.__name__) + message)
-
         if self._calc_types is None:
             message = 'invalid inputs generator `{}`: does not define `_calc_types`'.format(self.__class__.__name__)
             raise RuntimeError(message)


### PR DESCRIPTION
Python 3.7.8, which was installed by default has some issues with
`aiida-core`'s requirement for `pyyaml==5.1.2. Since we cannot release
this requirement very easily, we temporarily workaround it by pinning
3.7.7 for the tests job, which is the only job requiring Python 3.7.
Note that this required `setup-python@v2` since v1 does not allow
specifying an exact version.