### PR TITLE
Drop Python 3.5 support officially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7.7, 3.8]
+                python-version: [3.6, 3.7.7, 3.8]
 
         steps:
         -   uses: actions/checkout@v2

--- a/setup.json
+++ b/setup.json
@@ -8,13 +8,12 @@
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8"
     ],
     "description": "AiiDA package with utilities and interfaces for common workflows.",
-    "python_requires": ">=3.5",
+    "python_requires": ">=3.6",
     "install_requires": [
         "aiida-core[atomic_tools]~=1.2",
         "aiida-quantumespresso~=3.0",


### PR DESCRIPTION
Fixes #30 

Python 3.5 is officially EOL September 23rd 2020, which is in two
months, but most of the big libraries, such as `numpy` have long dropped
support for this minor version. There is little to no reason for this
package to continue supporting it and dropping it will allow us to use
all new features of Python 3.6, such as f-strings and full support for
the `pathlib.Path` module in the `os` interface.