### PR TITLE
CLI: allow to define resources for each engine step in relax launch

### DIFF
--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -112,3 +112,21 @@ DAEMON = options.OverridableOption(
     default=False,
     help='Submit the process to the daemon instead of running it locally.'
 )
+
+WALLCLOCK_SECONDS = options.OverridableOption(
+    '-w',
+    '--wallclock-seconds',
+    cls=options.MultipleValueOption,
+    metavar='VALUES',
+    required=False,
+    help='Define the wallclock seconds to request for each engine step.'
+)
+
+NUMBER_MACHINES = options.OverridableOption(
+    '-m',
+    '--number-machines',
+    cls=options.MultipleValueOption,
+    metavar='VALUES',
+    required=False,
+    help='Define the number of machines to request for each engine step.'
+)

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.cli.launch` module."""
+import click
+import pytest
+
+from aiida_common_workflows.cli.launch import cmd_relax
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_relax_wallclock_seconds(run_cli_command, generate_structure, generate_code):
+    """Test the `--wallclock-seconds` option."""
+    structure = generate_structure().store()
+    generate_code('quantumespresso.pw').store()
+
+    # Passing two values for `-w` should raise as only one value is required
+    options = ['-S', str(structure.pk), '-w', '100', '100', '--', 'quantum_espresso']
+    result = run_cli_command(cmd_relax, options, raises=click.BadParameter)
+    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+           'requires 1 values' in result.output_lines
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_relax_number_machines(run_cli_command, generate_structure, generate_code):
+    """Test the `--number-machines` option."""
+    structure = generate_structure().store()
+    generate_code('quantumespresso.pw').store()
+
+    # Passing two values for `-m` should raise as only one value is required
+    options = ['-S', str(structure.pk), '-m', '100', '100', '--', 'quantum_espresso']
+    result = run_cli_command(cmd_relax, options, raises=click.BadParameter)
+    assert 'Error: Invalid value for --number-machines: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+           'requires 1 values' in result.output_lines

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Pytest fixtures for unit tests."""
+import click
+import pytest
+
+pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
+
+
+@pytest.fixture
+def run_cli_command():
+    """Run a `click` command with the given options.
+
+    The call will raise if the command triggered an exception or the exit code returned is non-zero.
+    """
+    from click.testing import Result
+
+    def _run_cli_command(command: click.Command, options: list = None, raises: bool = False) -> Result:
+        """Run the command and check the result.
+
+        .. note:: the `output_lines` attribute is added to return value containing list of stripped output lines.
+
+        :param options: the list of command line options to pass to the command invocation
+        :param raises: whether the command is expected to raise an exception
+        :return: test result
+        """
+        import traceback
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(command, options or [])
+
+        if raises:
+            assert result.exception is not None, result.output
+            assert result.exit_code != 0
+        else:
+            assert result.exception is None, ''.join(traceback.format_exception(*result.exc_info))
+            assert result.exit_code == 0, result.output
+
+        result.output_lines = [line.strip() for line in result.output.split('\n') if line.strip()]
+
+        return result
+
+    return _run_cli_command
+
+
+@pytest.fixture
+def generate_structure():
+    """Generate a `StructureData` node."""
+
+    def _generate_structure():
+        from aiida.plugins import DataFactory
+        structure = DataFactory('structure')()
+        return structure
+
+    return _generate_structure
+
+
+@pytest.fixture
+def generate_code(aiida_localhost):
+    """Generate a `Code` node."""
+
+    def _generate_code(entry_point):
+        from aiida.plugins import DataFactory
+        code = DataFactory('code')(input_plugin_name=entry_point, remote_computer_exec=[aiida_localhost, '/bin/bash'])
+        return code
+
+    return _generate_code


### PR DESCRIPTION
Fixes #43 

Previously, the resources, i.e. the number of machines and wallclock
seconds, to be requested was hardcoded for all engine steps. Now these
are configurable through the `--wallclock-seconds` and
`--number-machines` options. There is validation to make sure they are
of equal length and match the number of engine steps for the common
relax workflow that is selected.

In addition, the code is now passed by its full label, which will make
sure it can be loaded even in case of ambiguity because there are
multiple codes with the same label configured for multiple computers.