### PR TITLE
Add pgtest dependence

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -27,7 +27,7 @@
     ],
     "extras_require": {
         "tests": [
-            "pytest~=5.4",
+	    "pytest~=5.4",
 	    "pgtest~=1.3,>=1.3.1"
         ],
         "pre-commit": [

--- a/setup.json
+++ b/setup.json
@@ -27,8 +27,8 @@
     ],
     "extras_require": {
         "tests": [
-	    "pytest~=5.4",
-	    "pgtest~=1.3,>=1.3.1"
+	      "pytest~=5.4",
+	      "pgtest~=1.3,>=1.3.1"
         ],
         "pre-commit": [
             "pre-commit~=2.2",

--- a/setup.json
+++ b/setup.json
@@ -27,7 +27,8 @@
     ],
     "extras_require": {
         "tests": [
-            "pytest~=5.4"
+            "pytest~=5.4",
+	    "pgtest==1.3.1"
         ],
         "pre-commit": [
             "pre-commit~=2.2",

--- a/setup.json
+++ b/setup.json
@@ -28,7 +28,7 @@
     "extras_require": {
         "tests": [
             "pytest~=5.4",
-	    "pgtest==1.3.1"
+	    "pgtest~=1.3,>=1.3.1"
         ],
         "pre-commit": [
             "pre-commit~=2.2",


### PR DESCRIPTION
The CI was failing because of missing `pgtest`. Added it to the requirements of `tests`. I don't know why tests were not failing before. Regarding the version of `pgtests` I pinned it to `1.3.1` because I remember it was in this way in `aiida-core` a bit ago. Now I see `pgtest~=1.3,>=1.3.1`. Do you remember a bit more about this issue @sphuber?