### PR TITLE
Added support for new relaxations types

### DIFF
--- a/aiida_common_workflows/cli/launch.py
+++ b/aiida_common_workflows/cli/launch.py
@@ -110,6 +110,7 @@ def cmd_relax(
 @click.argument('plugin', type=types.LazyChoice(functools.partial(get_workflow_entry_point_names, 'relax', True)))
 @options.STRUCTURE(help='The structure to relax.')
 @options.PROTOCOL(type=click.Choice(['fast', 'moderate', 'precise']), default='fast')
+@options.RELAXATION_TYPE(type=types.LazyChoice(options.get_relax_types_eos))
 @options.THRESHOLD_FORCES()
 @options.THRESHOLD_STRESS()
 @options.NUMBER_MACHINES()
@@ -117,8 +118,8 @@ def cmd_relax(
 @options.DAEMON()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
 def cmd_eos(
-    plugin, structure, protocol, threshold_forces, threshold_stress, number_machines, wallclock_seconds, daemon,
-    show_engines
+    plugin, structure, protocol, relaxation_type, threshold_forces, threshold_stress, number_machines,
+    wallclock_seconds, daemon, show_engines
 ):
     """Compute the equation of state of a crystal structure using the common relax workflow.
 
@@ -130,7 +131,6 @@ def cmd_eos(
     from aiida.orm import QueryBuilder, Code
     from aiida_common_workflows.plugins import get_entry_point_name_from_class
     from aiida_common_workflows.workflows.eos import EquationOfStateWorkChain
-    from aiida_common_workflows.workflows.relax import RelaxType
 
     process_class = load_workflow_entry_point('relax', plugin)
     generator = process_class.get_inputs_generator()
@@ -197,7 +197,7 @@ def cmd_eos(
         'generator_inputs': {
             'calc_engines': engines,
             'protocol': protocol,
-            'relaxation_type': RelaxType.ATOMS,
+            'relaxation_type': relaxation_type,
         },
         'sub_process_class': get_entry_point_name_from_class(process_class).name,
     }

--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -16,7 +16,7 @@ def get_workchain_plugins():
 
 
 def get_relax_types_eos():
-    """Return the relaxation types available for the common relax workflow."""
+    """Return the relaxation types available for the common equation of states workflow."""
     return [item.value for item in RelaxType if 'cell' not in item.value and 'volume' not in item.value]
 
 

--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -15,6 +15,11 @@ def get_workchain_plugins():
     return {name[len(entry_point_prefix):] for name in names if name.startswith(entry_point_prefix)}
 
 
+def get_relax_types_eos():
+    """Return the relaxation types available for the common relax workflow."""
+    return [item.value for item in RelaxType if 'cell' not in item.value and 'volume' not in item.value]
+
+
 def get_relax_types():
     """Return the relaxation types available for the common relax workflow."""
     return [entry.value for entry in RelaxType]

--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -3,7 +3,7 @@
 import inspect
 
 from aiida import orm
-from aiida.common import exceptions
+from aiida.common import exceptions, InputValidationError
 from aiida.engine import WorkChain, append_, calcfunction
 from aiida.plugins import WorkflowFactory
 
@@ -108,6 +108,12 @@ class EquationOfStateWorkChain(WorkChain):
         """Return the builder for the relax workchain."""
         structure = scale_structure(self.inputs.structure, scale_factor)
         process_class = WorkflowFactory(self.inputs.sub_process_class)
+
+        rel_type = self.inputs.generator_inputs.relaxation_type
+        if 'CELL' in rel_type.name or 'VOLUME' in rel_type.name:
+            raise InputValidationError(
+                'Equation of state and relaxation with variable volume are not compatible'
+                )
 
         builder = process_class.get_inputs_generator().get_builder(
             structure,

--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -3,7 +3,7 @@
 import inspect
 
 from aiida import orm
-from aiida.common import exceptions, InputValidationError
+from aiida.common import exceptions
 from aiida.engine import WorkChain, append_, calcfunction
 from aiida.plugins import WorkflowFactory
 
@@ -111,7 +111,7 @@ class EquationOfStateWorkChain(WorkChain):
 
         rel_type = self.inputs.generator_inputs.relaxation_type
         if 'CELL' in rel_type.name or 'VOLUME' in rel_type.name:
-            raise InputValidationError(
+            raise ValueError(
                 'Equation of state and relaxation with variable volume are not compatible'
                 )
 

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -11,9 +11,14 @@ __all__ = ('RelaxType', 'RelaxInputsGenerator')
 class RelaxType(Enum):
     """Enumeration of known relax types."""
 
+    NONE = 'none'
     ATOMS = 'atoms'
+    VOLUME = 'volume'
+    SHAPE = 'shape'
     CELL = 'cell'
     ATOMS_CELL = 'atoms_cell'
+    ATOMS_VOLUME = 'atoms_volume'
+    ATOMS_SHAPE = 'atoms_shape'
 
 
 class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):

--- a/aiida_common_workflows/workflows/relax/workchain.py
+++ b/aiida_common_workflows/workflows/relax/workchain.py
@@ -39,7 +39,7 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
             cls.inspect_workchain,
             cls.convert_outputs,
         )
-        spec.output('relaxed_structure', valid_type=StructureData,
+        spec.output('relaxed_structure', valid_type=StructureData, required=False,
             help='All cell dimensions and atomic positions are in Ångstrom.')
         spec.output('forces', valid_type=ArrayData,
             help='The final forces on all atoms in eV/Å.')

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -67,5 +67,5 @@ def test_eos_relax_types(run_cli_command, generate_structure, generate_code):
     # Passing two values for `-m` should raise as only one value is required
     options = ['-S', str(structure.pk), '-r', 'cell', 'quantum_espresso']
     result = run_cli_command(cmd_eos, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for "-r" / "--relaxation-type": invalid choice: cell. ' \
-           '(choose from none, atoms, shape, atoms_shape)' in result.output_lines
+    assert "Error: Invalid value for '-r' / '--relaxation-type': invalid choice: cell. " \
+            '(choose from none, atoms, shape, atoms_shape)' in result.output_lines

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -56,3 +56,16 @@ def test_eos_number_machines(run_cli_command, generate_structure, generate_code)
     result = run_cli_command(cmd_eos, options, raises=click.BadParameter)
     assert 'Error: Invalid value for --number-machines: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_eos_relax_types(run_cli_command, generate_structure, generate_code):
+    """Test the `--number-machines` option."""
+    structure = generate_structure().store()
+    generate_code('quantumespresso.pw').store()
+
+    # Passing two values for `-m` should raise as only one value is required
+    options = ['-S', str(structure.pk), '-r', 'cell', 'quantum_espresso']
+    result = run_cli_command(cmd_eos, options, raises=click.BadParameter)
+    assert 'Error: Invalid value for "-r" / "--relaxation-type": invalid choice: cell. ' \
+           '(choose from none, atoms, shape, atoms_shape)' in result.output_lines

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -60,11 +60,11 @@ def test_eos_number_machines(run_cli_command, generate_structure, generate_code)
 
 @pytest.mark.usefixtures('aiida_profile')
 def test_eos_relax_types(run_cli_command, generate_structure, generate_code):
-    """Test the `--number-machines` option."""
+    """Test the `--relaxation-type` option."""
     structure = generate_structure().store()
     generate_code('quantumespresso.pw').store()
 
-    # Passing two values for `-m` should raise as only one value is required
+    # Test that a non-sensical relaxation type raises
     options = ['-S', str(structure.pk), '-r', 'cell', 'quantum_espresso']
     result = run_cli_command(cmd_eos, options, raises=click.BadParameter)
     assert "Error: Invalid value for '-r' / '--relaxation-type': invalid choice: cell. " \


### PR DESCRIPTION
As decided in the meeting of the 04/11/2020:
* Added new entries to `RelaxTypes`
* Made the `relaxed_structure` optional output
* Implemented check on eos workchain to stop eos with variable volume relax
* Added to the eos CLI the option to choose the relaxation type