### PR TITLE
Add basic support for the relax types and optional relaxed_structure output

### DIFF
--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -23,11 +23,11 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
     _default_protocol = 'moderate'
     _calc_types = {'relax': {'code_plugin': 'abinit', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
-        RelaxType.NONE: 'Fix the atomic positions and volume and shape of the cell.',
+        RelaxType.NONE: 'Fix the atomic positions, cell volume, and cell shape.',
         RelaxType.ATOMS: 'Relax the atomic positions at fixed cell volume and shape.',
-        RelaxType.ATOMS_CELL: 'Relax the atomic positions, cell shape, and cell volume.',
+        RelaxType.ATOMS_CELL: 'Relax the atomic positions, cell volume, and cell shape.',
         RelaxType.ATOMS_VOLUME: 'Relax the atomic positions and cell volume at fixed cell shape.',
-        RelaxType.ATOMS_SHAPE: 'Relax the atomic positions cell shape at fixed cell volume.'
+        RelaxType.ATOMS_SHAPE: 'Relax the atomic positions and cell shape at fixed cell volume.'
     }
     _spin_types = {SpinType.NONE: '....', SpinType.COLLINEAR: '....'}
     _electronic_types = {ElectronicType.METAL: '....', ElectronicType.INSULATOR: '....'}

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -23,8 +23,22 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
     _default_protocol = 'moderate'
     _calc_types = {'relax': {'code_plugin': 'abinit', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
-        RelaxType.ATOMS: 'Relax only the atomic positions while keeping the cell fixed.',
-        RelaxType.ATOMS_CELL: 'Relax both atomic positions and the cell.'
+        RelaxType.NONE:
+        'Fix the atomic positions and volume and shape of the cell.',
+        RelaxType.ATOMS:
+        'Relax the atomic positions while keeping the volume and shape of the cell fixed.',
+        RelaxType.VOLUME:
+        'Relax the volume of the cell while keeping its shape and the atomic positions fixed.',
+        RelaxType.SHAPE:
+        'Relax the shape of the cell while keeping its volume and the atomic positions fixed.',
+        RelaxType.CELL:
+        'Relax the shape and volume of the cell while keeping the atomic positions fixed.',
+        RelaxType.ATOMS_CELL:
+        'Relax the atomic positions and volume and shape of the cell.',
+        RelaxType.ATOMS_VOLUME:
+        'Relax the atomic positions and volume of the cell while keeping the shape of the cell fixed.',
+        RelaxType.ATOMS_SHAPE:
+        'Relax the atomic positions and the shape of the cell while keeping the volume of the cell fixed.'
     }
 
     def __init__(self, *args, **kwargs):
@@ -120,11 +134,29 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
         inputs = generate_inputs(self.process_class._process_class, protocol, code, structure, override)  # pylint: disable=protected-access
         builder._update(inputs)  # pylint: disable=protected-access
 
-        if relaxation_type == RelaxType.ATOMS:
+        if relaxation_type == RelaxType.NONE:
+            optcell = 0
+            ionmov = 0
+        elif relaxation_type == RelaxType.ATOMS:
             optcell = 0
             ionmov = 22
+        elif relaxation_type == RelaxType.VOLUME:
+            optcell = 1
+            ionmov = 0
+        elif relaxation_type == RelaxType.SHAPE:
+            optcell = 3
+            ionmov = 0
+        elif relaxation_type == RelaxType.CELL:
+            optcell = 2
+            ionmov = 0
         elif relaxation_type == RelaxType.ATOMS_CELL:
             optcell = 2
+            ionmov = 22
+        elif relaxation_type == RelaxType.ATOMS_VOLUME:
+            optcell = 1
+            ionmov = 22
+        elif relaxation_type == RelaxType.ATOMS_SHAPE:
+            optcell = 3
             ionmov = 22
         else:
             raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -23,22 +23,11 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
     _default_protocol = 'moderate'
     _calc_types = {'relax': {'code_plugin': 'abinit', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
-        RelaxType.NONE:
-        'Fix the atomic positions and volume and shape of the cell.',
-        RelaxType.ATOMS:
-        'Relax the atomic positions at fixed cell volume and shape.',
-        # RelaxType.VOLUME:
-        # 'Relax the cell volume at fixed cell shape and relative atomic positions.',
-        # RelaxType.SHAPE:
-        # 'Relax the cell shape and at fixed cell volume and relative atomic positions.',
-        # RelaxType.CELL:
-        # 'Relax the cell shape and volume at fixed relative atomic positions.',
-        RelaxType.ATOMS_CELL:
-        'Relax the atomic positions, cell shape, and cell volume.',
-        RelaxType.ATOMS_VOLUME:
-        'Relax the atomic positions and cell volume at fixed cell shape.',
-        RelaxType.ATOMS_SHAPE:
-        'Relax the atomic positions cell shape at fixed cell volume.'
+        RelaxType.NONE: 'Fix the atomic positions and volume and shape of the cell.',
+        RelaxType.ATOMS: 'Relax the atomic positions at fixed cell volume and shape.',
+        RelaxType.ATOMS_CELL: 'Relax the atomic positions, cell shape, and cell volume.',
+        RelaxType.ATOMS_VOLUME: 'Relax the atomic positions and cell volume at fixed cell shape.',
+        RelaxType.ATOMS_SHAPE: 'Relax the atomic positions cell shape at fixed cell volume.'
     }
 
     def __init__(self, *args, **kwargs):
@@ -141,15 +130,6 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
         elif relaxation_type == RelaxType.ATOMS:
             optcell = 0
             ionmov = 22
-        # elif relaxation_type == RelaxType.VOLUME:#
-        #     optcell = 1
-        #     ionmov = 0
-        # elif relaxation_type == RelaxType.SHAPE:#
-        #     optcell = 3
-        #     ionmov = 0
-        # elif relaxation_type == RelaxType.CELL:#
-        #     optcell = 2
-        #     ionmov = 0
         elif relaxation_type == RelaxType.ATOMS_CELL:
             optcell = 2
             ionmov = 22

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -28,17 +28,17 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
         RelaxType.ATOMS:
         'Relax the atomic positions while keeping the volume and shape of the cell fixed.',
         RelaxType.VOLUME:
-        'Relax the volume of the cell while keeping its shape and the atomic positions fixed.',
+        'Relax the volume of the cell while keeping its shape and relative atomic positions fixed.',
         RelaxType.SHAPE:
-        'Relax the shape of the cell while keeping its volume and the atomic positions fixed.',
+        'Relax the shape of the cell while keeping its volume and the relative atomic positions fixed.',
         RelaxType.CELL:
-        'Relax the shape and volume of the cell while keeping the atomic positions fixed.',
+        'Relax the shape and volume of the cell while keeping the relative atomic positions fixed.',
         RelaxType.ATOMS_CELL:
         'Relax the atomic positions and volume and shape of the cell.',
         RelaxType.ATOMS_VOLUME:
-        'Relax the atomic positions and volume of the cell while keeping the shape of the cell fixed.',
+        'Relax the atomic positions and volume of the cell at fixed cell shape.',
         RelaxType.ATOMS_SHAPE:
-        'Relax the atomic positions and the shape of the cell while keeping the volume of the cell fixed.'
+        'Relax the atomic positions and the shape of the cell at fixed volume.'
     }
 
     def __init__(self, *args, **kwargs):
@@ -129,6 +129,7 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
                 parameters['nspinor'] = 2
 
         override['abinit']['parameters'] = parameters
+        override = recursive_merge(override, kwargs)
 
         builder = self.process_class.get_builder()
         inputs = generate_inputs(self.process_class._process_class, protocol, code, structure, override)  # pylint: disable=protected-access

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -26,19 +26,19 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
         RelaxType.NONE:
         'Fix the atomic positions and volume and shape of the cell.',
         RelaxType.ATOMS:
-        'Relax the atomic positions while keeping the volume and shape of the cell fixed.',
-        RelaxType.VOLUME:
-        'Relax the volume of the cell while keeping its shape and relative atomic positions fixed.',
-        RelaxType.SHAPE:
-        'Relax the shape of the cell while keeping its volume and the relative atomic positions fixed.',
-        RelaxType.CELL:
-        'Relax the shape and volume of the cell while keeping the relative atomic positions fixed.',
+        'Relax the atomic positions at fixed cell volume and shape.',
+        # RelaxType.VOLUME:
+        # 'Relax the cell volume at fixed cell shape and relative atomic positions.',
+        # RelaxType.SHAPE:
+        # 'Relax the cell shape and at fixed cell volume and relative atomic positions.',
+        # RelaxType.CELL:
+        # 'Relax the cell shape and volume at fixed relative atomic positions.',
         RelaxType.ATOMS_CELL:
-        'Relax the atomic positions and volume and shape of the cell.',
+        'Relax the atomic positions, cell shape, and cell volume.',
         RelaxType.ATOMS_VOLUME:
-        'Relax the atomic positions and volume of the cell at fixed cell shape.',
+        'Relax the atomic positions and cell volume at fixed cell shape.',
         RelaxType.ATOMS_SHAPE:
-        'Relax the atomic positions and the shape of the cell at fixed volume.'
+        'Relax the atomic positions cell shape at fixed cell volume.'
     }
 
     def __init__(self, *args, **kwargs):
@@ -141,15 +141,15 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
         elif relaxation_type == RelaxType.ATOMS:
             optcell = 0
             ionmov = 22
-        elif relaxation_type == RelaxType.VOLUME:
-            optcell = 1
-            ionmov = 0
-        elif relaxation_type == RelaxType.SHAPE:
-            optcell = 3
-            ionmov = 0
-        elif relaxation_type == RelaxType.CELL:
-            optcell = 2
-            ionmov = 0
+        # elif relaxation_type == RelaxType.VOLUME:#
+        #     optcell = 1
+        #     ionmov = 0
+        # elif relaxation_type == RelaxType.SHAPE:#
+        #     optcell = 3
+        #     ionmov = 0
+        # elif relaxation_type == RelaxType.CELL:#
+        #     optcell = 2
+        #     ionmov = 0
         elif relaxation_type == RelaxType.ATOMS_CELL:
             optcell = 2
             ionmov = 22
@@ -164,6 +164,10 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
 
         builder.abinit['parameters']['optcell'] = optcell
         builder.abinit['parameters']['ionmov'] = ionmov
+        if relaxation_type in [RelaxType.NONE, RelaxType.ATOMS]:
+            builder.abinit['parameters']['dilatmx'] = 1.00
+        elif builder.abinit['parameters'].get('dilatmx', None) is None:
+            builder.abinit['parameters']['dilatmx'] = 1.10
 
         if threshold_forces is not None:
             # The Abinit threshold_forces is in Ha/Bohr

--- a/aiida_common_workflows/workflows/relax/abinit/workchain.py
+++ b/aiida_common_workflows/workflows/relax/abinit/workchain.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Abinit."""
+import numpy as np
+
 from aiida import orm
 from aiida.engine import calcfunction
 from aiida.common import exceptions
@@ -12,18 +14,18 @@ __all__ = ('AbinitRelaxWorkChain',)
 
 
 @calcfunction
-def get_stress_from_trajectory(trajectory):
-    """Return the stress array from the given trajectory data."""
+def get_stress(parameters):
+    """Return the stress array from the given parameters node."""
     stress = orm.ArrayData()
-    stress.set_array(name='stress', array=trajectory.get_array('stress')[-1])
+    stress.set_array(name='stress', array=np.array(parameters.get_attribute('cart_stress_tensor')))
     return stress
 
 
 @calcfunction
-def get_forces_from_trajectory(trajectory):
-    """Return the forces array from the given trajectory data."""
+def get_forces(parameters):
+    """Return the forces array from the given parameters node."""
     forces = orm.ArrayData()
-    forces.set_array(name='forces', array=trajectory.get_array('forces')[-1])
+    forces.set_array(name='forces', array=np.array(parameters.get_attribute('forces')))
     return forces
 
 
@@ -46,5 +48,5 @@ class AbinitRelaxWorkChain(CommonRelaxWorkChain):
         except exceptions.NotExistentAttributeError:
             pass
         self.out('total_energy', get_total_energy(self.ctx.workchain.outputs.output_parameters))
-        self.out('forces', get_forces_from_trajectory(self.ctx.workchain.outputs.output_trajectory))
-        self.out('stress', get_stress_from_trajectory(self.ctx.workchain.outputs.output_trajectory))
+        self.out('forces', get_forces(self.ctx.workchain.outputs.output_parameters))
+        self.out('stress', get_stress(self.ctx.workchain.outputs.output_parameters))

--- a/aiida_common_workflows/workflows/relax/abinit/workchain.py
+++ b/aiida_common_workflows/workflows/relax/abinit/workchain.py
@@ -2,6 +2,7 @@
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Abinit."""
 from aiida import orm
 from aiida.engine import calcfunction
+from aiida.common import exceptions
 from aiida_abinit.workflows.base import AbinitBaseWorkChain
 
 from ..workchain import CommonRelaxWorkChain
@@ -40,7 +41,10 @@ class AbinitRelaxWorkChain(CommonRelaxWorkChain):
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""
-        self.out('relaxed_structure', self.ctx.workchain.outputs.output_structure)
+        try:
+            self.out('relaxed_structure', self.ctx.workchain.outputs.output_structure)
+        except exceptions.NotExistentAttributeError:
+            pass
         self.out('total_energy', get_total_energy(self.ctx.workchain.outputs.output_parameters))
         self.out('forces', get_forces_from_trajectory(self.ctx.workchain.outputs.output_trajectory))
         self.out('stress', get_stress_from_trajectory(self.ctx.workchain.outputs.output_trajectory))


### PR DESCRIPTION
Abinit supports all of the new relax types, and I have added support for all of them in the Abinit inputs generator.
Because of `RelaxType.None`, I've also added some basic logic to handle the case with no output structure. 