### PR TITLE
`RelaxInputsGenerator.get_builder`: use keyword arguments only syntax

### DIFF
--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -74,7 +74,7 @@ class EquationOfStateWorkChain(WorkChain):
         spec.input('generator_inputs.calc_engines', valid_type=dict, non_db=True)
         spec.input('generator_inputs.protocol', valid_type=str, non_db=True,
             help='The protocol to use when determining the workchain inputs.')
-        spec.input('generator_inputs.relaxation_type', valid_type=RelaxType, non_db=True,
+        spec.input('generator_inputs.relax_type', valid_type=RelaxType, non_db=True,
             help='The type of relaxation to perform.')
         spec.input('generator_inputs.threshold_forces', valid_type=float, required=False, non_db=True,
             help='Target threshold for the forces in eV/Å.')
@@ -109,11 +109,9 @@ class EquationOfStateWorkChain(WorkChain):
         structure = scale_structure(self.inputs.structure, scale_factor)
         process_class = WorkflowFactory(self.inputs.sub_process_class)
 
-        rel_type = self.inputs.generator_inputs.relaxation_type
-        if 'CELL' in rel_type.name or 'VOLUME' in rel_type.name:
-            raise ValueError(
-                'Equation of state and relaxation with variable volume are not compatible'
-                )
+        relax_type = self.inputs.generator_inputs.relax_type
+        if 'CELL' in relax_type.name or 'VOLUME' in relax_type.name:
+            raise ValueError('Equation of state and relaxation with variable volume are not compatible')
 
         builder = process_class.get_inputs_generator().get_builder(
             structure,

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -3,7 +3,7 @@
 import collections
 import copy
 import pathlib
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import yaml
 from pymatgen.core import units
@@ -46,31 +46,47 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
         self,
         structure: StructureData,
         calc_engines: Dict[str, Any],
-        protocol,
-        relaxation_type: RelaxType,
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
     ) -> engine.ProcessBuilder:
         """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
-        :param structure: the structure to be relaxed
-        :param calc_engines: ...
-        :param protocol: the protocol to use when determining the workchain inputs
-        :param relaxation_type: the type of relaxation to perform, instance of `RelaxType`
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
         :param threshold_forces: target threshold for the forces in eV/Å.
         :param threshold_stress: target threshold for the stress in eV/Å^3.
+        :param previous_workchain: a <Code>RelaxWorkChain node.
+        :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
         # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-
         super().get_builder(
-            structure, calc_engines, protocol, relaxation_type, threshold_forces, threshold_stress, previous_workchain,
-            electronic_type, spin_type, magnetization_per_site, **kwargs
+            structure,
+            calc_engines,
+            protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
         )
 
         protocol = copy.deepcopy(self.get_protocol(protocol))
@@ -129,27 +145,27 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
         inputs = generate_inputs(self.process_class._process_class, protocol, code, structure, override)  # pylint: disable=protected-access
         builder._update(inputs)  # pylint: disable=protected-access
 
-        if relaxation_type == RelaxType.NONE:
+        if relax_type == RelaxType.NONE:
             optcell = 0
             ionmov = 0
-        elif relaxation_type == RelaxType.ATOMS:
+        elif relax_type == RelaxType.ATOMS:
             optcell = 0
             ionmov = 22
-        elif relaxation_type == RelaxType.ATOMS_CELL:
+        elif relax_type == RelaxType.ATOMS_CELL:
             optcell = 2
             ionmov = 22
-        elif relaxation_type == RelaxType.ATOMS_VOLUME:
+        elif relax_type == RelaxType.ATOMS_VOLUME:
             optcell = 1
             ionmov = 22
-        elif relaxation_type == RelaxType.ATOMS_SHAPE:
+        elif relax_type == RelaxType.ATOMS_SHAPE:
             optcell = 3
             ionmov = 22
         else:
-            raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))
+            raise ValueError('relaxation type `{}` is not supported'.format(relax_type.value))
 
         builder.abinit['parameters']['optcell'] = optcell
         builder.abinit['parameters']['ionmov'] = ionmov
-        if relaxation_type in [RelaxType.NONE, RelaxType.ATOMS]:
+        if relax_type in [RelaxType.NONE, RelaxType.ATOMS]:
             builder.abinit['parameters']['dilatmx'] = 1.00
         elif builder.abinit['parameters'].get('dilatmx', None) is None:
             builder.abinit['parameters']['dilatmx'] = 1.10

--- a/aiida_common_workflows/workflows/relax/bigdft/generator.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/generator.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for BigDFT."""
+from typing import Any, Dict, List
+
+from aiida import engine
 from aiida import orm
-from aiida.plugins import DataFactory
+from aiida import plugins
+
 from ..generator import RelaxInputsGenerator, RelaxType, SpinType, ElectronicType
 
 __all__ = ('BigDftRelaxInputsGenerator',)
 
-BigDFTParameters = DataFactory('bigdft')
+BigDFTParameters = plugins.DataFactory('bigdft')
+StructureData = plugins.DataFactory('structure')
 
 
 class BigDftRelaxInputsGenerator(RelaxInputsGenerator):
@@ -56,31 +61,55 @@ class BigDftRelaxInputsGenerator(RelaxInputsGenerator):
 
     def get_builder(
         self,
-        structure,
-        calc_engines,
-        protocol,
-        relaxation_type,
-        threshold_forces=None,
-        threshold_stress=None,
+        structure: StructureData,
+        calc_engines: Dict[str, Any],
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
+        threshold_forces: float = None,
+        threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
-    ):  # pylint: disable=too-many-locals
+    ) -> engine.ProcessBuilder:
+        """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
+        :param threshold_forces: target threshold for the forces in eV/Å.
+        :param threshold_stress: target threshold for the stress in eV/Å^3.
+        :param previous_workchain: a <Code>RelaxWorkChain node.
+        :param kwargs: any inputs that are specific to the plugin.
+        :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
+        """
+        # pylint: disable=too-many-locals
         super().get_builder(
-            structure, calc_engines, protocol, relaxation_type, threshold_forces, threshold_stress, previous_workchain,
-            electronic_type, spin_type, magnetization_per_site, **kwargs
+            structure,
+            calc_engines,
+            protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
         )
 
-        from aiida.orm import Dict
-        from aiida.orm import load_code
-
-        if relaxation_type == RelaxType.ATOMS:
+        if relax_type == RelaxType.ATOMS:
             relaxation_schema = 'relax'
         else:
-            raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))
+            raise ValueError('relaxation type `{}` is not supported'.format(relax_type.value))
 
         builder = self.process_class.get_builder()
         builder.structure = structure
@@ -94,9 +123,9 @@ class BigDftRelaxInputsGenerator(RelaxInputsGenerator):
             inputdict = self.get_protocol(protocol)['inputdict_linear']
 
         builder.parameters = BigDFTParameters(dict=inputdict)
-        builder.code = load_code(calc_engines[relaxation_schema]['code'])
+        builder.code = orm.load_code(calc_engines[relaxation_schema]['code'])
         run_opts = {'options': calc_engines[relaxation_schema]['options']}
-        builder.run_opts = Dict(dict=run_opts)
+        builder.run_opts = orm.Dict(dict=run_opts)
 
         if threshold_forces is not None:
             builder.relax.threshold_forces = orm.Float(threshold_forces)

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -2,7 +2,7 @@
 """Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for CP2K."""
 import collections
 import pathlib
-from typing import Any, Dict
+from typing import Any, Dict, List
 import yaml
 
 from aiida import engine
@@ -103,31 +103,47 @@ class Cp2kRelaxInputsGenerator(RelaxInputsGenerator):
         self,
         structure: StructureData,
         calc_engines: Dict[str, Any],
-        protocol,
-        relaxation_type: RelaxType,
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
     ) -> engine.ProcessBuilder:
         """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
-        :param structure: the structure to be relaxed
-        :param calc_engines: ...
-        :param protocol: the protocol to use when determining the workchain inputs
-        :param relaxation_type: the type of relaxation to perform, instance of `RelaxType`
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
         :param threshold_forces: target threshold for the forces in eV/Å.
         :param threshold_stress: target threshold for the stress in eV/Å^3.
+        :param previous_workchain: a <Code>RelaxWorkChain node.
+        :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
         # pylint: disable=too-many-locals
-
         super().get_builder(
-            structure, calc_engines, protocol, relaxation_type, threshold_forces, threshold_stress, previous_workchain,
-            electronic_type, spin_type, magnetization_per_site, **kwargs
+            structure,
+            calc_engines,
+            protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
         )
 
         # The builder.
@@ -151,12 +167,12 @@ class Cp2kRelaxInputsGenerator(RelaxInputsGenerator):
         dict_merge(parameters, kinds_section)
 
         ## Relaxation type.
-        if relaxation_type == RelaxType.ATOMS:
+        if relax_type == RelaxType.ATOMS:
             run_type = 'GEO_OPT'
-        elif relaxation_type == RelaxType.ATOMS_CELL:
+        elif relax_type == RelaxType.ATOMS_CELL:
             run_type = 'CELL_OPT'
         else:
-            raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))
+            raise ValueError('relaxation type `{}` is not supported'.format(relax_type.value))
         parameters['GLOBAL'] = {'RUN_TYPE': run_type}
 
         ## Redefining forces threshold.

--- a/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -2,13 +2,17 @@
 """Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for FLEUR."""
 import collections
 import pathlib
-from typing import Any, Dict
+from typing import Any, Dict, List
 import yaml
+
+from aiida import engine
 from aiida import orm
-from aiida.orm import Code, load_node
+from aiida import plugins
 from ..generator import RelaxInputsGenerator, RelaxType, SpinType, ElectronicType
 
 __all__ = ('FleurRelaxInputsGenerator',)
+
+StructureData = plugins.DataFactory('structure')
 
 
 class FleurRelaxInputsGenerator(RelaxInputsGenerator):
@@ -58,46 +62,58 @@ class FleurRelaxInputsGenerator(RelaxInputsGenerator):
 
     def get_builder(
         self,
-        structure,
-        calc_engines,
-        protocol,
-        relaxation_type,
-        threshold_forces=None,
-        threshold_stress=None,
+        structure: StructureData,
+        calc_engines: Dict[str, Any],
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
+        threshold_forces: float = None,
+        threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
-    ):
-        """Return a process builder for the corresponding workchain class with
-           inputs set according to the protocol.
+    ) -> engine.ProcessBuilder:
+        """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
-        :param structure: the structure to be relaxed
-        :param calc_engines: ...
-        :param protocol: the protocol to use when determining the workchain inputs
-        :param relaxation_type: the type of relaxation to perform, instance of `RelaxType`
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
         :param threshold_forces: target threshold for the forces in eV/Å.
         :param threshold_stress: target threshold for the stress in eV/Å^3.
-        :param previous_workchain: AiiDA workchain node from which information can be extracted
+        :param previous_workchain: a <Code>RelaxWorkChain node.
         :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
         # pylint: disable=too-many-locals
-        from aiida.orm import load_code
-
         super().get_builder(
-            structure, calc_engines, protocol, relaxation_type, threshold_forces, threshold_stress, previous_workchain,
-            electronic_type, spin_type, magnetization_per_site, **kwargs
+            structure,
+            calc_engines,
+            protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
         )
 
         # pylint: disable=too-many-locals
         inpgen_code = calc_engines['inpgen']['code']
         fleur_code = calc_engines['relax']['code']
-        if not isinstance(inpgen_code, Code):
-            inpgen_code = load_code(inpgen_code)
-        if not isinstance(fleur_code, Code):
-            fleur_code = load_code(fleur_code)
+        if not isinstance(inpgen_code, orm.Code):
+            inpgen_code = orm.load_code(inpgen_code)
+        if not isinstance(fleur_code, orm.Code):
+            fleur_code = orm.load_code(fleur_code)
 
         # Checks if protocol exists
         if protocol not in self.get_protocol_names():
@@ -113,10 +129,10 @@ class FleurRelaxInputsGenerator(RelaxInputsGenerator):
         # has to go over calc parameters, kmax, lmax, kpoint density
         # inputs = generate_scf_inputs(process_class, protocol, code, structure)
 
-        if relaxation_type == RelaxType.ATOMS:
+        if relax_type == RelaxType.ATOMS:
             relaxation_mode = 'force'
         else:
-            raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))
+            raise ValueError('relaxation type `{}` is not supported'.format(relax_type.value))
 
         if threshold_forces is not None:
             # Fleur expects atomic units i.e Hartree/bohr
@@ -202,9 +218,9 @@ def get_parameters(previous_workchain):
     # Find Fleurinp
     try:
         last_base_relax = find_last_submitted_workchain(previous_workchain)
-        last_relax = find_last_submitted_workchain(load_node(last_base_relax))
-        last_scf = find_last_submitted_workchain(load_node(last_relax))
-        last_scf = load_node(last_scf)
+        last_relax = find_last_submitted_workchain(orm.load_node(last_base_relax))
+        last_scf = find_last_submitted_workchain(orm.load_node(last_relax))
+        last_scf = orm.load_node(last_scf)
     except NotExistent:
         # something went wrong in the previous workchain run
         #.. we just continue without previous parameters but defaults.

--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for Gaussian."""
-
 import copy
+from typing import Any, Dict, List
+
 import numpy as np
 
+from aiida import engine
 from aiida import orm
 from aiida import plugins
 
@@ -64,26 +66,53 @@ class GaussianRelaxInputsGenerator(RelaxInputsGenerator):
 
     def get_builder(
         self,
-        structure,
-        calc_engines,
-        protocol,
-        relaxation_type,
-        threshold_forces=None,
-        threshold_stress=None,
+        structure: StructureData,
+        calc_engines: Dict[str, Any],
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
+        threshold_forces: float = None,
+        threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
-    ):
+    ) -> engine.ProcessBuilder:
+        """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
+
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
+        :param threshold_forces: target threshold for the forces in eV/Å.
+        :param threshold_stress: target threshold for the stress in eV/Å^3.
+        :param previous_workchain: a <Code>RelaxWorkChain node.
+        :param kwargs: any inputs that are specific to the plugin.
+        :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
+        """
         # pylint: disable=too-many-locals
         super().get_builder(
-            structure, calc_engines, protocol, relaxation_type, threshold_forces, threshold_stress, previous_workchain,
-            electronic_type, spin_type, magnetization_per_site, **kwargs
+            structure,
+            calc_engines,
+            protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
         )
 
-        if relaxation_type != RelaxType.ATOMS:
-            raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))
+        if relax_type != RelaxType.ATOMS:
+            raise ValueError('relax type `{}` is not supported'.format(relax_type.value))
 
         # -----------------------------------------------------------------
         # Set the link0 memory and n_proc based on the calc_engines options dict

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
-"""Module with base input generator for the common structure relaxation workchains."""
+"""Module with base input generator for the common structure relax workchains."""
 from abc import ABCMeta, abstractmethod
 from enum import Enum
+from typing import Any, Dict, List
 
+from aiida import engine
+from aiida import plugins
 from aiida_common_workflows.protocol import ProtocolRegistry
 
 __all__ = ('ElectronicType', 'SpinType', 'RelaxType', 'RelaxInputsGenerator')
+
+StructureData = plugins.DataFactory('structure')
 
 
 class RelaxType(Enum):
@@ -39,7 +44,7 @@ class ElectronicType(Enum):
 
 
 class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):
-    """Input generator for the common structure relaxation workchains.
+    """Input generator for the common structure relax workchains.
 
     Subclasses should define the `_calc_types`, `_spin_types`, `_electronic_types` and `_relax_types` class attributes,
     as well as the `get_builder` method.
@@ -93,33 +98,33 @@ class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):
     @abstractmethod
     def get_builder(
         self,
-        structure,
-        calc_engines,
-        protocol,
-        relaxation_type,
-        threshold_forces=None,
-        threshold_stress=None,
+        structure: StructureData,
+        calc_engines: Dict[str, Any],
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
+        threshold_forces: float = None,
+        threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
-    ):
+    ) -> engine.ProcessBuilder:
         """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
         :param structure: the structure to be relaxed.
         :param calc_engines: a dictionary containing the computational resources for the relaxation.
         :param protocol: the protocol to use when determining the workchain inputs.
-        :param relaxation_type: the type of relaxation to perform, instance of `RelaxType`.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
         :param threshold_forces: target threshold for the forces in eV/Å.
         :param threshold_stress: target threshold for the stress in eV/Å^3.
         :param previous_workchain: a <Code>RelaxWorkChain node.
-        :param electronic_type: electronics for the calculation (metal, insulator, ...), instance of `ElectronicType`.
-        :param spin_type: the spin polarization type to use for the calculation, instance of `SpinType`.
-        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or
-                                       integer in units of electrons.
-                                       If not defined, the builder will automatically define the initial
-                                       magnetization if and only if `spin_type != SpinType.NONE`.
         :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
@@ -131,8 +136,8 @@ class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):
             except AttributeError:
                 raise ValueError('The "previous_workchain" must be a node of {}'.format(self.process_class))
 
-        if relaxation_type not in self._relax_types:
-            raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type))
+        if relax_type not in self._relax_types:
+            raise ValueError('relax type `{}` is not supported'.format(relax_type))
 
         if electronic_type not in self._electronic_types:
             raise ValueError('electronic type `{}` is not supported'.format(electronic_type))
@@ -157,8 +162,8 @@ class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):
         except KeyError:
             raise ValueError('the calculation type `{}` does not exist'.format(key))
 
-    def get_relaxation_types(self):
-        """Return the available relaxation types for this input generator."""
+    def get_relax_types(self):
+        """Return the available relax types for this input generator."""
         return list(self._relax_types.keys())
 
     def get_spin_types(self):

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -2,7 +2,7 @@
 """Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for Quantum ESPRESSO."""
 import collections
 import pathlib
-from typing import Any, Dict
+from typing import Any, Dict, List
 import yaml
 
 from aiida import engine
@@ -44,31 +44,47 @@ class QuantumEspressoRelaxInputsGenerator(RelaxInputsGenerator):
         self,
         structure: StructureData,
         calc_engines: Dict[str, Any],
-        protocol,
-        relaxation_type: RelaxType,
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
     ) -> engine.ProcessBuilder:
         """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
-        :param structure: the structure to be relaxed
-        :param calc_engines: ...
-        :param protocol: the protocol to use when determining the workchain inputs
-        :param relaxation_type: the type of relaxation to perform, instance of `RelaxType`
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
         :param threshold_forces: target threshold for the forces in eV/Å.
         :param threshold_stress: target threshold for the stress in eV/Å^3.
+        :param previous_workchain: a <Code>RelaxWorkChain node.
+        :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
         # pylint: disable=too-many-locals
-
         super().get_builder(
-            structure, calc_engines, protocol, relaxation_type, threshold_forces, threshold_stress, previous_workchain,
-            electronic_type, spin_type, magnetization_per_site, **kwargs
+            structure,
+            calc_engines,
+            protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
         )
 
         from qe_tools import CONSTANTS
@@ -81,12 +97,12 @@ class QuantumEspressoRelaxInputsGenerator(RelaxInputsGenerator):
         inputs = generate_inputs(self.process_class._process_class, protocol, code, structure, override)  # pylint: disable=protected-access
         builder._update(inputs)  # pylint: disable=protected-access
 
-        if relaxation_type == RelaxType.ATOMS:
+        if relax_type == RelaxType.ATOMS:
             relaxation_schema = 'relax'
-        elif relaxation_type == RelaxType.ATOMS_CELL:
+        elif relax_type == RelaxType.ATOMS_CELL:
             relaxation_schema = 'vc-relax'
         else:
-            raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))
+            raise ValueError('relaxation type `{}` is not supported'.format(relax_type.value))
 
         builder.relaxation_scheme = orm.Str(relaxation_schema)
 

--- a/aiida_common_workflows/workflows/relax/siesta/generator.py
+++ b/aiida_common_workflows/workflows/relax/siesta/generator.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for SIESTA."""
 import os
+from typing import Any, Dict, List
+
 import yaml
+
+from aiida import engine
+from aiida import orm
+from aiida import plugins
 from aiida.common import exceptions
-from aiida.orm import Group
 from ..generator import RelaxInputsGenerator, RelaxType, SpinType, ElectronicType
 
 __all__ = ('SiestaRelaxInputsGenerator',)
+
+StructureData = plugins.DataFactory('structure')
 
 
 class SiestaRelaxInputsGenerator(RelaxInputsGenerator):
@@ -77,40 +84,64 @@ class SiestaRelaxInputsGenerator(RelaxInputsGenerator):
 
     def get_builder(
         self,
-        structure,
-        calc_engines,
-        protocol,
-        relaxation_type,
-        threshold_forces=None,
-        threshold_stress=None,
+        structure: StructureData,
+        calc_engines: Dict[str, Any],
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
+        threshold_forces: float = None,
+        threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
-    ):  # pylint: disable=too-many-locals
+    ) -> engine.ProcessBuilder:
+        """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
+        :param threshold_forces: target threshold for the forces in eV/Å.
+        :param threshold_stress: target threshold for the stress in eV/Å^3.
+        :param previous_workchain: a <Code>RelaxWorkChain node.
+        :param kwargs: any inputs that are specific to the plugin.
+        :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
+        """
+        # pylint: disable=too-many-locals
         super().get_builder(
-            structure, calc_engines, protocol, relaxation_type, threshold_forces, threshold_stress, previous_workchain,
-            electronic_type, spin_type, magnetization_per_site, **kwargs
+            structure,
+            calc_engines,
+            protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
         )
-
-        from aiida.orm import Dict
-        from aiida.orm import load_code
 
         # Checks
         if protocol not in self.get_protocol_names():
             import warnings
             warnings.warn('no protocol implemented with name {}, using default moderate'.format(protocol))
             protocol = self.get_default_protocol_name()
-        if relaxation_type not in self.get_relaxation_types():
-            raise ValueError('Wrong relaxation type: no relax_type with name {} implemented'.format(relaxation_type))
+        if relax_type not in self.get_relax_types():
+            raise ValueError('Wrong relaxation type: no relax_type with name {} implemented'.format(relax_type))
         if 'relaxation' not in calc_engines:
             raise ValueError('The `calc_engines` dictionaly must contain "relaxation" as outermost key')
 
         pseudo_family = self._protocols[protocol]['pseudo_family']
         try:
-            Group.objects.get(label=pseudo_family)
+            orm.Group.objects.get(label=pseudo_family)
         except exceptions.NotExistent:
             raise ValueError(
                 'protocol `{}` requires `pseudo_family` with name {} '
@@ -124,9 +155,9 @@ class SiestaRelaxInputsGenerator(RelaxInputsGenerator):
         parameters = self._get_param(protocol, structure)
         parameters['md-type-of-run'] = 'cg'
         parameters['md-num-cg-steps'] = 100
-        if relaxation_type == RelaxType.ATOMS_CELL:
+        if relax_type == RelaxType.ATOMS_CELL:
             parameters['md-variable-cell'] = True
-        # if relaxation_type == 'constant_volume':
+        # if relax_type == 'constant_volume':
         #     parameters['md-variable-cell'] = True
         #     parameters['md-constant-volume'] = True
         if threshold_forces:
@@ -142,13 +173,13 @@ class SiestaRelaxInputsGenerator(RelaxInputsGenerator):
 
         builder = self.process_class.get_builder()
         builder.structure = structure
-        builder.basis = Dict(dict=basis)
-        builder.parameters = Dict(dict=parameters)
+        builder.basis = orm.Dict(dict=basis)
+        builder.parameters = orm.Dict(dict=parameters)
         if kpoints_mesh:
             builder.kpoints = kpoints_mesh
         builder.pseudo_family = pseudo_family
-        builder.options = Dict(dict=calc_engines['relaxation']['options'])
-        builder.code = load_code(calc_engines['relaxation']['code'])
+        builder.options = orm.Dict(dict=calc_engines['relaxation']['options'])
+        builder.code = orm.load_code(calc_engines['relaxation']['code'])
 
         return builder
 

--- a/aiida_common_workflows/workflows/relax/submission_template.py
+++ b/aiida_common_workflows/workflows/relax/submission_template.py
@@ -84,11 +84,11 @@ assert set(InpGen.get_protocol('moderate')) == {
 
 # Another compulsory input, specifying the task. Typical values: 'atoms', 'cell'
 # but every plugin is free to implement its own
-relaxation_type = 'atoms'
+relax_type = 'atoms'
 
 # As some codes might support limited functionality (for instance fleur can't relax the cell),
-# it is useful to have a method returning the available `relaxation_type`
-assert set(InpGen.get_relaxation_types()) == set(['atoms', 'cell', 'atoms_cell'])
+# it is useful to have a method returning the available `relax_type`
+assert set(InpGen.get_relax_types()) == set(['atoms', 'cell', 'atoms_cell'])
 
 #Other inputs the user need to define:
 structure = StructureData()  # The initial structure is a compulsory input
@@ -107,7 +107,7 @@ builder = rel_inp_gen.get_builder(
     structure=structure,
     calc_engines=calc_engines,
     protocol=protocol,
-    relaxation_type=relaxation_type,
+    relax_type=relax_type,
     threshold_forces=threshold_forces,
     threshold_stress=threshold_stress
 )

--- a/aiida_common_workflows/workflows/relax/vasp/generator.py
+++ b/aiida_common_workflows/workflows/relax/vasp/generator.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for VASP."""
 import pathlib
+from typing import Any, Dict, List
+
 import yaml
 
-from aiida.plugins import DataFactory
-from aiida.orm import Code
+from aiida import engine
+from aiida import orm
+from aiida import plugins
 from aiida.common.extendeddicts import AttributeDict
 
 from ..generator import RelaxInputsGenerator, RelaxType, SpinType, ElectronicType
 
 __all__ = ('VaspRelaxInputsGenerator',)
+
+StructureData = plugins.DataFactory('structure')
 
 
 class VaspRelaxInputsGenerator(RelaxInputsGenerator):
@@ -43,34 +48,49 @@ class VaspRelaxInputsGenerator(RelaxInputsGenerator):
 
     def get_builder(
         self,
-        structure,
-        calc_engines,
-        protocol,
-        relaxation_type,
-        threshold_forces=None,
-        threshold_stress=None,
+        structure: StructureData,
+        calc_engines: Dict[str, Any],
+        protocol: str,
+        *,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: List[float] = None,
+        threshold_forces: float = None,
+        threshold_stress: float = None,
         previous_workchain=None,
-        electronic_type=ElectronicType.METAL,
-        spin_type=SpinType.NONE,
-        magnetization_per_site=None,
         **kwargs
-    ):
+    ) -> engine.ProcessBuilder:
         """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
-        :param structure: the structure to be relaxed
-        :param calc_engines: ...
-        :param protocol: the protocol to use when determining the workchain inputs
-        :param relaxation_type: the type of relaxation to perform, instance of `RelaxType`
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list with the initial spin polarization for each site. Float or integer in
+            units of electrons. If not defined, the builder will automatically define the initial magnetization if and
+            only if `spin_type != SpinType.NONE`.
         :param threshold_forces: target threshold for the forces in eV/Å.
         :param threshold_stress: target threshold for the stress in eV/Å^3.
+        :param previous_workchain: a <Code>RelaxWorkChain node.
         :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
         # pylint: disable=too-many-locals
-
         super().get_builder(
-            structure, calc_engines, protocol, relaxation_type, threshold_forces, threshold_stress, previous_workchain,
-            electronic_type, spin_type, magnetization_per_site, **kwargs
+            structure,
+            calc_engines,
+            protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
         )
 
         # Get the protocol that we want to use
@@ -82,32 +102,34 @@ class VaspRelaxInputsGenerator(RelaxInputsGenerator):
         builder = self.process_class.get_builder()
 
         # Set code
-        builder.code = Code.get_from_string(calc_engines['relax']['code'])
+        builder.code = orm.load_code(calc_engines['relax']['code'])
 
         # Set structure
         builder.structure = structure
 
         # Set options
-        builder.options = DataFactory('dict')(dict=calc_engines['relax']['options'])
+        builder.options = plugins.DataFactory('dict')(dict=calc_engines['relax']['options'])
 
         # Set settings
         # Make sure we add forces and stress for the VASP parser
         settings = AttributeDict()
         settings.update({'parser_settings': {'add_forces': True, 'add_stress': True}})
-        builder.settings = DataFactory('dict')(dict=settings)
+        builder.settings = plugins.DataFactory('dict')(dict=settings)
 
         # Set workchain related inputs, in this case, give more explicit output to report
-        builder.verbose = DataFactory('bool')(True)
+        builder.verbose = plugins.DataFactory('bool')(True)
 
         # Set parameters
-        builder.parameters = DataFactory('dict')(dict=protocol['parameters'])
+        builder.parameters = plugins.DataFactory('dict')(dict=protocol['parameters'])
 
         # Set potentials and their mapping
-        builder.potential_family = DataFactory('str')(protocol['potential_family'])
-        builder.potential_mapping = DataFactory('dict')(dict=self._potential_mapping[protocol['potential_mapping']])
+        builder.potential_family = plugins.DataFactory('str')(protocol['potential_family'])
+        builder.potential_mapping = plugins.DataFactory('dict')(
+            dict=self._potential_mapping[protocol['potential_mapping']]
+        )
 
         # Set the kpoint grid from the density in the protocol
-        kpoints = DataFactory('array.kpoints')()
+        kpoints = plugins.DataFactory('array.kpoints')()
         kpoints.set_kpoints_mesh([1, 1, 1])
         kpoints.set_cell_from_structure(structure)
         rec_cell = kpoints.reciprocal_cell
@@ -118,29 +140,29 @@ class VaspRelaxInputsGenerator(RelaxInputsGenerator):
         # After a while these will be set in the VASP workchain entrypoints using the convergence workchain etc.
         # However, for now we rely on defaults plane wave cutoffs and a set k-point density for the chosen protocol.
         relax = AttributeDict()
-        relax.perform = DataFactory('bool')(True)
-        relax.algo = DataFactory('str')(protocol['relax']['algo'])
+        relax.perform = plugins.DataFactory('bool')(True)
+        relax.algo = plugins.DataFactory('str')(protocol['relax']['algo'])
 
-        if relaxation_type == RelaxType.ATOMS:
-            relax.positions = DataFactory('bool')(True)
-            relax.shape = DataFactory('bool')(False)
-            relax.volume = DataFactory('bool')(False)
-        elif relaxation_type == RelaxType.CELL:
-            relax.positions = DataFactory('bool')(False)
-            relax.shape = DataFactory('bool')(True)
-            relax.volume = DataFactory('bool')(True)
-        elif relaxation_type == RelaxType.ATOMS_CELL:
-            relax.positions = DataFactory('bool')(True)
-            relax.shape = DataFactory('bool')(True)
-            relax.volume = DataFactory('bool')(True)
+        if relax_type == RelaxType.ATOMS:
+            relax.positions = plugins.DataFactory('bool')(True)
+            relax.shape = plugins.DataFactory('bool')(False)
+            relax.volume = plugins.DataFactory('bool')(False)
+        elif relax_type == RelaxType.CELL:
+            relax.positions = plugins.DataFactory('bool')(False)
+            relax.shape = plugins.DataFactory('bool')(True)
+            relax.volume = plugins.DataFactory('bool')(True)
+        elif relax_type == RelaxType.ATOMS_CELL:
+            relax.positions = plugins.DataFactory('bool')(True)
+            relax.shape = plugins.DataFactory('bool')(True)
+            relax.volume = plugins.DataFactory('bool')(True)
         else:
-            raise ValueError('relaxation type `{}` is not supported'.format(relaxation_type.value))
+            raise ValueError('relaxation type `{}` is not supported'.format(relax_type.value))
 
         if threshold_forces is not None:
             threshold = threshold_forces
         else:
             threshold = protocol['relax']['threshold_forces']
-        relax.force_cutoff = DataFactory('float')(threshold)
+        relax.force_cutoff = plugins.DataFactory('float')(threshold)
 
         if threshold_stress is not None:
             raise ValueError('Using a stress threshold is not directly available in VASP during relaxation.')

--- a/tests/workflows/relax/test_generator.py
+++ b/tests/workflows/relax/test_generator.py
@@ -45,10 +45,10 @@ def inputs_generator(protocol_registry) -> RelaxInputsGenerator:
     return InputsGenerator(process_class=CommonRelaxWorkChain)
 
 
-def test_validation(protocol_registry):  #pylint: disable=too-many-statements
+def test_validation(protocol_registry):
     """Test the validation of subclasses of `ProtocolRegistry`."""
 
-    # pylint: disable=abstract-class-instantiated,function-redefined
+    # pylint: disable=abstract-class-instantiated,function-redefined,too-many-statements
 
     class InputsGenerator(protocol_registry, RelaxInputsGenerator):
         """Invalid inputs generator implementation: no ``get_builder``"""
@@ -183,9 +183,9 @@ def test_get_calc_type_schema(inputs_generator):
     assert inputs_generator.get_calc_type_schema('relax') == {'code_plugin': 'entry.point', 'description': 'test'}
 
 
-def test_get_relaxation_types(inputs_generator):
-    """Test `RelaxInputsGenerator.get_relaxation_types`."""
-    assert set(inputs_generator.get_relaxation_types()) == {RelaxType.ATOMS, RelaxType.ATOMS_CELL}
+def test_get_relax_types(inputs_generator):
+    """Test `RelaxInputsGenerator.get_relax_types`."""
+    assert set(inputs_generator.get_relax_types()) == {RelaxType.ATOMS, RelaxType.ATOMS_CELL}
 
 
 def test_get_spin_types(inputs_generator):


### PR DESCRIPTION
All arguments for the `get_builder` method are marked as keyword
argument only, except for `structure`, `calc_engines` and `protocol`.
This will make the interface more stable with respect to changes we
might have to apply in the future. If we want to add new arguments,
change their order etc. by making them keyword only, calls of this
method will not be affected.

The choice to make `structure`, `calc_engines` and `protocol` positional
arguments is that they are always required and don't have a default.

In addition, the argument `relaxation_type` is renamed to `relax_type`
which makes more sense given that the enum that it takes is called
`RelaxType`.