### PR TITLE
Gaussian improvements

### DIFF
--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -27,7 +27,7 @@ class GaussianRelaxInputsGenerator(RelaxInputsGenerator):
         'fast': {
             'description': 'Optimal performance, minimal accuracy.',
             'functional': 'PBEPBE',
-            'basis_set': 'STO-3G',
+            'basis_set': 'Def2SVP',
             'route_parameters': {
                 'nosymm': None,
                 'opt': None,
@@ -36,7 +36,7 @@ class GaussianRelaxInputsGenerator(RelaxInputsGenerator):
         'moderate': {
             'description': 'Moderate performance, moderate accuracy.',
             'functional': 'PBEPBE',
-            'basis_set': '6-31+G(d,p)',
+            'basis_set': 'Def2TZVP',
             'route_parameters': {
                 'int': 'ultrafine',
                 'nosymm': None,
@@ -46,7 +46,7 @@ class GaussianRelaxInputsGenerator(RelaxInputsGenerator):
         'precise': {
             'description': 'Low performance, high accuracy',
             'functional': 'PBEPBE',
-            'basis_set': '6-311+G(d,p)',
+            'basis_set': 'Def2QZVP',
             'route_parameters': {
                 'int': 'superfine',
                 'nosymm': None,

--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -100,7 +100,7 @@ class GaussianRelaxInputsGenerator(RelaxInputsGenerator):
         :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals,too-many-branches
         protocol = protocol or self.get_default_protocol_name()
 
         super().get_builder(
@@ -155,7 +155,7 @@ class GaussianRelaxInputsGenerator(RelaxInputsGenerator):
         sel_protocol = copy.deepcopy(self.get_protocol(protocol))
         route_params = sel_protocol['route_parameters']
 
-        if relaxation_type == RelaxType.NONE:
+        if relax_type == RelaxType.NONE:
             del route_params['opt']
             route_params['force'] = None
 

--- a/aiida_common_workflows/workflows/relax/gaussian/workchain.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/workchain.py
@@ -40,6 +40,7 @@ class GaussianRelaxWorkChain(CommonRelaxWorkChain):
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""
-        self.out('relaxed_structure', self.ctx.workchain.outputs.output_structure)
+        if "output_structure" in self.ctx.workchain.outputs:
+            self.out('relaxed_structure', self.ctx.workchain.outputs.output_structure)
         self.out('total_energy', get_total_energy(self.ctx.workchain.outputs.output_parameters))
         self.out('forces', get_forces(self.ctx.workchain.outputs.output_parameters))

--- a/aiida_common_workflows/workflows/relax/gaussian/workchain.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/workchain.py
@@ -40,7 +40,7 @@ class GaussianRelaxWorkChain(CommonRelaxWorkChain):
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""
-        if "output_structure" in self.ctx.workchain.outputs:
+        if 'output_structure' in self.ctx.workchain.outputs:
             self.out('relaxed_structure', self.ctx.workchain.outputs.output_structure)
         self.out('total_energy', get_total_energy(self.ctx.workchain.outputs.output_parameters))
         self.out('forces', get_forces(self.ctx.workchain.outputs.output_parameters))


### PR DESCRIPTION
Hi! I implemented the `RelaxType.NONE` and a version of spin logic. I ignored the `is_insulator` logic, as it isn't really relevant for Gaussian.

Regarding the spin logic: I implemented such that in case of `SpinType.NONE`, a restricted (RKS) and in case of `SpinType.COLLINEAR` an unrestricted Kohn-Sham (UKS) calculation is performed. In case of the UKS, `guess=mix is used`, which mixes the RKS HOMO & LUMO to try to break the spin symmetry and produce a spin-polarized result. The `magnetization_per_site` I ignored for now, as Gaussian doesn't provide a straightforward way to set the spin guess per atom. In principle Gaussian allows to divide the system into multiple fragments and set initial spin multiplicities for each fragment but this requires testing to see if it could be adapted to our case. Also the pymatgen input generator for the plugin doesn't support this, so it would take some time to re-write the plugin.

But if spin-unrestricted calculations are supported, shouldn't we also support setting the input multiplicity? It's one of the main inputs to quantum chemistry codes (Gaussian, Orca, Cp2k). We can discuss this in the meeting.

Regarding `previous_workchain`, I think indeed that this doesn't really apply to Gaussian. The whole input is determined by the protocol & there is no k-point equivalent that is set e.g. in Siesta.