### PR TITLE
CLI: rename `RELAXATION_TYPE` to `RELAX_TYPE`

### DIFF
--- a/aiida_common_workflows/cli/launch.py
+++ b/aiida_common_workflows/cli/launch.py
@@ -22,7 +22,7 @@ def cmd_launch():
 @click.argument('plugin', type=types.LazyChoice(functools.partial(get_workflow_entry_point_names, 'relax', True)))
 @options.STRUCTURE(help='The structure to relax.')
 @options.PROTOCOL(type=click.Choice(['fast', 'moderate', 'precise']), default='fast')
-@options.RELAXATION_TYPE()
+@options.RELAX_TYPE()
 @options.SPIN_TYPE()
 @options.THRESHOLD_FORCES()
 @options.THRESHOLD_STRESS()
@@ -31,7 +31,7 @@ def cmd_launch():
 @options.DAEMON()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
 def cmd_relax(
-    plugin, structure, protocol, relaxation_type, spin_type, threshold_forces, threshold_stress, number_machines,
+    plugin, structure, protocol, relax_type, spin_type, threshold_forces, threshold_stress, number_machines,
     wallclock_seconds, daemon, show_engines
 ):
     """Relax a crystal structure using the common relax workflow for one of the existing plugin implementations.
@@ -107,7 +107,7 @@ def cmd_relax(
         structure,
         engines,
         protocol=protocol,
-        relax_type=relaxation_type,
+        relax_type=relax_type,
         threshold_forces=threshold_forces,
         threshold_stress=threshold_stress,
         spin_type=spin_type
@@ -119,7 +119,7 @@ def cmd_relax(
 @click.argument('plugin', type=types.LazyChoice(functools.partial(get_workflow_entry_point_names, 'relax', True)))
 @options.STRUCTURE(help='The structure to relax.')
 @options.PROTOCOL(type=click.Choice(['fast', 'moderate', 'precise']), default='fast')
-@options.RELAXATION_TYPE(type=types.LazyChoice(options.get_relax_types_eos))
+@options.RELAX_TYPE(type=types.LazyChoice(options.get_relax_types_eos))
 @options.SPIN_TYPE()
 @options.THRESHOLD_FORCES()
 @options.THRESHOLD_STRESS()
@@ -128,7 +128,7 @@ def cmd_relax(
 @options.DAEMON()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
 def cmd_eos(
-    plugin, structure, protocol, relaxation_type, spin_type, threshold_forces, threshold_stress, number_machines,
+    plugin, structure, protocol, relax_type, spin_type, threshold_forces, threshold_stress, number_machines,
     wallclock_seconds, daemon, show_engines
 ):
     """Compute the equation of state of a crystal structure using the common relax workflow.
@@ -207,7 +207,7 @@ def cmd_eos(
         'generator_inputs': {
             'calc_engines': engines,
             'protocol': protocol,
-            'relax_type': relaxation_type,
+            'relax_type': relax_type,
             'spin_type': spin_type,
         },
         'sub_process_class': get_entry_point_name_from_class(process_class).name,

--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -91,14 +91,14 @@ PROTOCOL = options.OverridableOption(
     help='Select the protocol with which the inputs for the workflow should be generated.'
 )
 
-RELAXATION_TYPE = options.OverridableOption(
+RELAX_TYPE = options.OverridableOption(
     '-r',
-    '--relaxation-type',
+    '--relax-type',
     type=types.LazyChoice(get_relax_types),
     default='atoms',
     show_default=True,
     callback=lambda ctx, value: RelaxType(value),
-    help='Select the relaxation type with which the workflow should be run.'
+    help='Select the relax type with which the workflow should be run.'
 )
 
 SPIN_TYPE = options.OverridableOption(

--- a/aiida_common_workflows/workflows/relax/abinit/eos_abinit.py
+++ b/aiida_common_workflows/workflows/relax/abinit/eos_abinit.py
@@ -29,7 +29,7 @@ CALC_ENGINES = {
 
 def launch():
     """Launch the relax work chain for a basic silicon crystal structure at a range of scaling factors."""
-    relaxation_type = RelaxType.ATOMS
+    relax_type = RelaxType.ATOMS
     protocol = 'moderate'
 
     structure = structure_init()
@@ -38,7 +38,7 @@ def launch():
         scaled = rescale(structure, scale)
         generator = RelaxWorkChain.get_inputs_generator()
         #import pdb; pdb.set_trace()
-        builder = generator.get_builder(scaled, CALC_ENGINES, protocol, relaxation_type, threshold_forces=0.001)
+        builder = generator.get_builder(scaled, CALC_ENGINES, protocol, relax_type, threshold_forces=0.001)
         results = run(builder)
         print(results['relaxed_structure'].get_cell_volume(), results['total_energy'].value)
 

--- a/aiida_common_workflows/workflows/relax/abinit/eos_abinit2.py
+++ b/aiida_common_workflows/workflows/relax/abinit/eos_abinit2.py
@@ -40,7 +40,7 @@ def launch():
         'sub_process_class': 'common_workflows.relax.abinit',
         'generator_inputs': {
             'protocol': 'precise',
-            'relaxation_type': RelaxType.ATOMS,
+            'relax_type': RelaxType.ATOMS,
             'threshold_forces': 0.001,
             'calc_engines': {
                 'relax': {

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -163,7 +163,7 @@ class AbinitRelaxInputsGenerator(RelaxInputsGenerator):
             optcell = 3
             ionmov = 22
         else:
-            raise ValueError('relaxation type `{}` is not supported'.format(relax_type.value))
+            raise ValueError('relax type `{}` is not supported'.format(relax_type.value))
 
         builder.abinit['parameters']['optcell'] = optcell
         builder.abinit['parameters']['ionmov'] = ionmov

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -174,7 +174,7 @@ class Cp2kRelaxInputsGenerator(RelaxInputsGenerator):
         elif relax_type == RelaxType.ATOMS_CELL:
             run_type = 'CELL_OPT'
         else:
-            raise ValueError('relaxation type `{}` is not supported'.format(relax_type.value))
+            raise ValueError('relax type `{}` is not supported'.format(relax_type.value))
         parameters['GLOBAL'] = {'RUN_TYPE': run_type}
 
         ## Redefining forces threshold.

--- a/aiida_common_workflows/workflows/relax/siesta/generator.py
+++ b/aiida_common_workflows/workflows/relax/siesta/generator.py
@@ -137,7 +137,7 @@ class SiestaRelaxInputsGenerator(RelaxInputsGenerator):
             warnings.warn('no protocol implemented with name {}, using default moderate'.format(protocol))
             protocol = self.get_default_protocol_name()
         if relax_type not in self.get_relax_types():
-            raise ValueError('Wrong relaxation type: no relax_type with name {} implemented'.format(relax_type))
+            raise ValueError('Wrong relax type: no relax_type with name {} implemented'.format(relax_type))
         if 'relaxation' not in calc_engines:
             raise ValueError('The `calc_engines` dictionaly must contain "relaxation" as outermost key')
 

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -60,12 +60,12 @@ def test_eos_number_machines(run_cli_command, generate_structure, generate_code)
 
 @pytest.mark.usefixtures('aiida_profile')
 def test_eos_relax_types(run_cli_command, generate_structure, generate_code):
-    """Test the `--relaxation-type` option."""
+    """Test the `--relax-type` option."""
     structure = generate_structure().store()
     generate_code('quantumespresso.pw').store()
 
-    # Test that a non-sensical relaxation type raises
+    # Test that a non-sensical relax type raises
     options = ['-S', str(structure.pk), '-r', 'cell', 'quantum_espresso']
     result = run_cli_command(cmd_eos, options, raises=click.BadParameter)
-    assert "Error: Invalid value for '-r' / '--relaxation-type': invalid choice: cell. " \
+    assert "Error: Invalid value for '-r' / '--relax-type': invalid choice: cell. " \
             '(choose from none, atoms, shape, atoms_shape)' in result.output_lines


### PR DESCRIPTION
The argument for input generators was already renamed to `relax_type`
so it is best that the CLI is consistent and uses `--relax-type` as well
instead of `--relaxation-type`.