### PR TITLE
Add CODES option to launch cmds

### DIFF
--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -92,6 +92,18 @@ class StructureDataParamType(click.Choice):
         return structure
 
 
+CODES = options.OverridableOption(
+    '-X',
+    '--codes',
+    'codes',
+    type=types.CodeParamType(),
+    cls=options.MultipleValueOption,
+    help='One or multiple codes identified by their ID, UUID or label. What codes are required is dependent on the '
+    'selected plugin and can be shown using the `--show-engines` option. If no explicit codes are specified, one will '
+    'be loaded from the database based on the required input plugins. If multiple codes are matched, a random one will '
+    'be selected.'
+)
+
 STRUCTURE = options.OverridableOption(
     '-S',
     '--structure',
@@ -116,7 +128,7 @@ RELAX_TYPE = options.OverridableOption(
     type=types.LazyChoice(get_relax_types),
     default='atoms',
     show_default=True,
-    callback=lambda ctx, value: RelaxType(value),
+    callback=lambda ctx, param, value: RelaxType(value),
     help='Select the relax type with which the workflow should be run.'
 )
 
@@ -126,7 +138,7 @@ SPIN_TYPE = options.OverridableOption(
     type=types.LazyChoice(get_spin_types),
     default='none',
     show_default=True,
-    callback=lambda ctx, value: SpinType(value),
+    callback=lambda ctx, param, value: SpinType(value),
     help='Select the spin type with which the workflow should be run.'
 )
 

--- a/aiida_common_workflows/cli/utils.py
+++ b/aiida_common_workflows/cli/utils.py
@@ -58,3 +58,27 @@ def launch_process(process, daemon, **inputs):
         click.echo('Running a {}...'.format(process_name))
         _, node = launch.run_get_node(process, **inputs)
         echo_process_results(node)
+
+
+def get_code_from_list_or_database(codes, entry_point: str):
+    """Return a code that is configured for the given calculation job entry point.
+
+    First the list of ``Code`` instances is scanned for a suitable code and if not found, one is attempted to be loaded
+    from the database. If no codes are found, ``None`` is returned.
+
+    :param codes: list of aiida `Code` nodes.
+    :param entry_point: calculation job entry point name.
+    :return: a ``Code`` instance configured for the given entry point or ``None``.
+    """
+    from aiida.orm import QueryBuilder, Code
+
+    for entry in codes:
+        if entry.get_attribute('input_plugin') == entry_point:
+            return entry
+
+    result = QueryBuilder().append(Code, filters={'attributes.input_plugin': entry_point}).first()
+
+    if result is not None:
+        return result[0]
+
+    return None

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.cli.utils` module."""
+import pytest
+
+from aiida_common_workflows.cli.utils import get_code_from_list_or_database
+
+
+@pytest.mark.usefixtures('clear_database_before_test')
+def test_get_code_from_list_or_database(generate_code):
+    """Test `get_code_from_list_or_database` method."""
+    entry_point = 'quantumespresso.pw'
+
+    # No explicit codes nor stored in the database
+    assert get_code_from_list_or_database([], entry_point) is None
+
+    codes = [generate_code(entry_point).store(), generate_code(entry_point).store()]
+
+    # From explicit code list
+    assert get_code_from_list_or_database(codes, entry_point).uuid == codes[0].uuid
+
+    # Empty list, but database contains a code. Note that order is random here, so we don't know which code is returned.
+    assert get_code_from_list_or_database([], entry_point).uuid in [code.uuid for code in codes]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,8 +74,14 @@ def generate_code(aiida_localhost):
     """Generate a `Code` node."""
 
     def _generate_code(entry_point):
+        import random
+        import string
         from aiida.plugins import DataFactory
-        code = DataFactory('code')(input_plugin_name=entry_point, remote_computer_exec=[aiida_localhost, '/bin/bash'])
+
+        label = ''.join(random.choice(string.ascii_letters) for _ in range(16))
+        code = DataFactory('code')(
+            label=label, input_plugin_name=entry_point, remote_computer_exec=[aiida_localhost, '/bin/bash']
+        )
         return code
 
     return _generate_code


### PR DESCRIPTION
Fixes #74 

So far given codes which are not used are just ignored.
Uses the first code from the list matching the code_plugin.

Tested it on QM. for no list, full list, half a list, no code of plugin present in db