### PR TITLE
EoS workchain: add validators.

### DIFF
--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -46,9 +46,9 @@ def validate_scale_increment(value, _):
         return 'scale increment needs to be between 0 and 1.'
 
 
-def validate_relax(value, _):
+def validate_relax_type(value, _):
     """Validate the `generator_inputs.relax_type` input."""
-    if 'CELL' in value.name or 'VOLUME' in value.name:
+    if value not in [RelaxType.NONE, RelaxType.ATOMS, RelaxType.SHAPE, RelaxType.ATOMS_SHAPE]:
         return '`generator_inputs.relax_type`. Equation of state and relaxation with variable volume not compatible.'
 
 
@@ -80,14 +80,14 @@ class EquationOfStateWorkChain(WorkChain):
         spec.input('generator_inputs.calc_engines', valid_type=dict, non_db=True)
         spec.input('generator_inputs.protocol', valid_type=str, non_db=True,
             help='The protocol to use when determining the workchain inputs.')
-        spec.input('generator_inputs.relax_type', valid_type=RelaxType, non_db=True, validator=validate_relax,
+        spec.input('generator_inputs.relax_type', valid_type=RelaxType, non_db=True, validator=validate_relax_type,
             help='The type of relaxation to perform.')
         spec.input('generator_inputs.spin_type', valid_type=SpinType, required=False, non_db=True,
             help='The type of spin for the calculation.')
         spec.input('generator_inputs.electronic_type', valid_type=ElectronicType, required=False, non_db=True,
             help='The type of electronics (insulator/metal) for the calculation.')
         spec.input('generator_inputs.magnetization_per_site', valid_type=orm.List, required=False, non_db=True,
-            help='List containing the initial magnetization fer each site.')
+            help='List containing the initial magnetization per atomic site.')
         spec.input('generator_inputs.threshold_forces', valid_type=float, required=False, non_db=True,
             help='Target threshold for the forces in eV/Å.')
         spec.input('generator_inputs.threshold_stress', valid_type=float, required=False, non_db=True,

--- a/tests/workflows/eos/test_workchain.py
+++ b/tests/workflows/eos/test_workchain.py
@@ -71,8 +71,8 @@ def test_validate_scale_increment(ctx):
 
 
 @pytest.mark.usefixtures('with_database')
-def test_validate_relax(ctx):
-    """Test the `validate_relax` validator."""
+def test_validate_relax_type(ctx):
+    """Test the `validate_relax_type` validator."""
     assert eos.validate_relax(RelaxType.NONE, ctx) is None
     assert eos.validate_relax(
         RelaxType.CELL, ctx

--- a/tests/workflows/eos/test_workchain.py
+++ b/tests/workflows/eos/test_workchain.py
@@ -10,6 +10,7 @@ from aiida.plugins import WorkflowFactory
 from aiida_common_workflows.plugins import get_workflow_entry_point_names
 from aiida_common_workflows.workflows import eos
 from aiida_common_workflows.workflows.relax.workchain import CommonRelaxWorkChain
+from aiida_common_workflows.workflows.relax.generator import RelaxType
 
 
 @pytest.fixture
@@ -67,3 +68,12 @@ def test_validate_scale_increment(ctx):
     assert eos.validate_scale_increment(orm.Float(1), ctx) == 'scale increment needs to be between 0 and 1.'
     assert eos.validate_scale_increment(orm.Float(-0.0001), ctx) == 'scale increment needs to be between 0 and 1.'
     assert eos.validate_scale_increment(orm.Float(1.00001), ctx) == 'scale increment needs to be between 0 and 1.'
+
+
+@pytest.mark.usefixtures('with_database')
+def test_validate_relax(ctx):
+    """Test the `validate_relax` validator."""
+    assert eos.validate_relax(RelaxType.NONE, ctx) is None
+    assert eos.validate_relax(
+        RelaxType.CELL, ctx
+    ) == '`generator_inputs.relax_type`. Equation of state and relaxation with variable volume not compatible.'

--- a/tests/workflows/eos/test_workchain.py
+++ b/tests/workflows/eos/test_workchain.py
@@ -73,7 +73,7 @@ def test_validate_scale_increment(ctx):
 @pytest.mark.usefixtures('with_database')
 def test_validate_relax_type(ctx):
     """Test the `validate_relax_type` validator."""
-    assert eos.validate_relax(RelaxType.NONE, ctx) is None
-    assert eos.validate_relax(
+    assert eos.validate_relax_type(RelaxType.NONE, ctx) is None
+    assert eos.validate_relax_type(
         RelaxType.CELL, ctx
     ) == '`generator_inputs.relax_type`. Equation of state and relaxation with variable volume not compatible.'


### PR DESCRIPTION
Added validators for new optional keys allowed in the `generator_inputs`
dictionary (input of the EoS workchain). They reflect the last changes
in the `get_builder` signature, meaning the addition of `spin_type`,
`electronic_type` and `magnetization_per_site` arguments.

Also moved the check on the allowed relaxation types to a dedicated validator.