### PR TITLE
The `magnetization_per_site` optional in eos cli

### DIFF
--- a/aiida_common_workflows/cli/launch.py
+++ b/aiida_common_workflows/cli/launch.py
@@ -214,7 +214,6 @@ def cmd_eos(
             'protocol': protocol,
             'relax_type': relax_type,
             'spin_type': spin_type,
-            'magnetization_per_site': magnetization_per_site,
         },
         'sub_process_class': get_entry_point_name_from_class(process_class).name,
     }
@@ -224,6 +223,9 @@ def cmd_eos(
 
     if threshold_stress is not None:
         inputs['generator_inputs']['threshold_stress'] = threshold_stress
+
+    if magnetization_per_site is not None:
+        inputs['generator_inputs']['magnetization_per_site'] = magnetization_per_site
 
     utils.launch_process(EquationOfStateWorkChain, daemon, **inputs)
 


### PR DESCRIPTION
The `magnetization_per_site` option of cli was not treated as option in the eos command of CLI.
Fixed