### PR TITLE
minor tweaks for the CASTEP implementation

### DIFF
--- a/aiida_common_workflows/workflows/relax/castep/protocol.yml
+++ b/aiida_common_workflows/workflows/relax/castep/protocol.yml
@@ -8,7 +8,7 @@ moderate:
         base:
             kpoints_spacing: 0.04
             pseudos_family: 'C19'
-            max_iterations: 2
+            max_iterations: 5
             calc:
                 parameters:
                     task: geometryoptimisation
@@ -37,7 +37,7 @@ precise:
         base:
             kpoints_spacing: 0.03
             pseudos_family: 'C19'
-            max_iterations: 2
+            max_iterations: 5
             calc:
                 parameters:
                     task: geometryoptimisation
@@ -67,7 +67,7 @@ fast:
         base:
             kpoints_spacing: 0.07
             pseudos_family: 'QC5'
-            max_iterations: 2
+            max_iterations: 5
             calc:
                 parameters:
                     task: geometryoptimisation

--- a/setup.json
+++ b/setup.json
@@ -27,7 +27,7 @@
         "aiida-quantumespresso~=3.2",
         "aiida-siesta~=1.1",
         "aiida-sssp~=0.1.0",
-        "aiida-castep>=1.2.0a4",
+        "aiida-castep>=1.2.0a5",
         "aiida-vasp"
     ],
     "extras_require": {


### PR DESCRIPTION
Increase the iterations for the `CastepBaseWorkChain`. This will handle density mixing better for edge cases.
Also bumped version for `aiida-castep` to 1.2.0a5.