### PR TITLE
Cp2kRelaxWorkChain update:

### DIFF
--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -236,7 +236,6 @@ class Cp2kRelaxInputsGenerator(RelaxInputsGenerator):
 
         elif spin_type == SpinType.COLLINEAR:
             parameters['FORCE_EVAL']['DFT']['UKS'] = True
-            print()
             structure, magnetization_tags = tags_and_magnetization(structure, magnetization_per_site)
             parameters['FORCE_EVAL']['DFT']['MULTIPLICITY'] = guess_multiplicity(structure, magnetization_per_site)
 

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -211,7 +211,10 @@ class Cp2kRelaxInputsGenerator(RelaxInputsGenerator):
 
         ## Kpoints.
         kpoints_distance = parameters.pop('kpoints_distance', None)
-        builder.cp2k.kpoints = self._get_kpoints(kpoints_distance, structure, previous_workchain)
+        kpoints = self._get_kpoints(kpoints_distance, structure, previous_workchain)
+        mesh, _ = kpoints.get_kpoints_mesh()
+        if mesh != [1, 1, 1]:
+            builder.cp2k.kpoints = kpoints
 
         ## Removing description.
         _ = parameters.pop('description')
@@ -278,6 +281,9 @@ class Cp2kRelaxInputsGenerator(RelaxInputsGenerator):
 
         # Run options.
         builder.cp2k.metadata.options = calc_engines['relax']['options']
+
+        # Use advanced parser to parse more data.
+        builder.cp2k.metadata.options['parser_name'] = 'cp2k_advanced_parser'
 
         return builder
 

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -48,7 +48,7 @@ def get_kinds_section(structure: StructureData, magnetization_tags=None):
     }
     for symbol, tag in symbol_tag:
         new_atom = {
-            '_': symbol + tag,
+            '_': symbol if tag == '0' else symbol + tag,
             'BASIS_SET': atom_data['basis_set'][symbol],
             'POTENTIAL': atom_data['pseudopotential'][symbol],
         }

--- a/aiida_common_workflows/workflows/relax/cp2k/protocol.yml
+++ b/aiida_common_workflows/workflows/relax/cp2k/protocol.yml
@@ -1,15 +1,12 @@
 moderate: # main settings exploiting OT
   description: 'Protocol to relax a structure with normal precision at moderate computational cost.'
+  kpoints_distance: 0.5
   GLOBAL:
     PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
   FORCE_EVAL:
     METHOD:         QUICKSTEP
     STRESS_TENSOR:  ANALYTICAL
     DFT:
-      KPOINTS:
-        SCHEME: "MONKHORST-PACK 3 3 3"
-        SYMMETRY: "OFF"
-        WAVEFUNCTIONS: "COMPLEX"
       BASIS_SET_FILE_NAME:
         - BASIS_MOLOPT
         - BASIS_MOLOPT_UCL
@@ -36,11 +33,10 @@ moderate: # main settings exploiting OT
           EPS_SCF:   1.0E-6
         DIAGONALIZATION:
           EPS_ADAPT: 0.01
-
         MIXING:
-          METHOD: DIRECT_P_MIXING
-          ALPHA:  0.4
-          BETA:   0.5
+          METHOD: BROYDEN_MIXING
+          ALPHA:  0.1
+          BETA:   1.5
       XC:
         XC_FUNCTIONAL:
           PBE:
@@ -125,16 +121,13 @@ moderate: # main settings exploiting OT
 
 precise:
   description: 'Protocol to relax a structure with high precision at higher computational cost.'
+  kpoints_distance: 0.2
   GLOBAL:
     PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
   FORCE_EVAL:
     METHOD:         QUICKSTEP
     STRESS_TENSOR:  ANALYTICAL
     DFT:
-      KPOINTS:
-        SCHEME: "MONKHORST-PACK 3 3 3"
-        SYMMETRY: "OFF"
-        WAVEFUNCTIONS: "COMPLEX"
       BASIS_SET_FILE_NAME:
         - BASIS_MOLOPT
         - BASIS_MOLOPT_UCL
@@ -161,11 +154,10 @@ precise:
           EPS_SCF:   1.0E-6          # ROBUST: equal (or smaller for expert use) than SCF/EPS_SCF
         DIAGONALIZATION:
           EPS_ADAPT: 0.01
-
         MIXING:
-          METHOD: DIRECT_P_MIXING
-          ALPHA:  0.4 # = Default: it does not seem to contribute much
-          BETA:   0.5 # = Default: it does not seem to contribute much
+          METHOD: BROYDEN_MIXING
+          ALPHA:  0.1
+          BETA:   1.5
       XC:
         XC_FUNCTIONAL:
           PBE:
@@ -250,6 +242,7 @@ precise:
 
 fast:  # WARNING: this protocal wasn't tested properly.
   description: 'Protocol to relax a structure with low precision at minimal computational cost for testing purposes.'
+  kpoints_distance: 1.0
   GLOBAL:
     PRINT_LEVEL: MEDIUM
   FORCE_EVAL:

--- a/aiida_common_workflows/workflows/relax/cp2k/protocol.yml
+++ b/aiida_common_workflows/workflows/relax/cp2k/protocol.yml
@@ -41,12 +41,6 @@ moderate: # main settings exploiting OT
         XC_FUNCTIONAL:
           PBE:
             PARAMETRIZATION: ORIG
-        VDW_POTENTIAL:
-           POTENTIAL_TYPE:  PAIR_POTENTIAL
-           PAIR_POTENTIAL:
-              PARAMETER_FILE_NAME:   dftd3.dat
-              TYPE:                  DFTD3(BJ)
-              REFERENCE_FUNCTIONAL:   PBE
       PRINT:
         MO_CUBES:
           WRITE_CUBE: F
@@ -162,12 +156,6 @@ precise:
         XC_FUNCTIONAL:
           PBE:
             PARAMETRIZATION: ORIG
-        VDW_POTENTIAL:
-           POTENTIAL_TYPE:  PAIR_POTENTIAL
-           PAIR_POTENTIAL:
-              PARAMETER_FILE_NAME:   dftd3.dat
-              TYPE:                  DFTD3(BJ)
-              REFERENCE_FUNCTIONAL:   PBE
       PRINT:
         MO_CUBES:
           WRITE_CUBE: F


### PR DESCRIPTION
1. Generalize k-points setup.
2. If kpoints mesh is [1, 1, 1] do not add the kpoints section.
3. Use advanced parser to parse more data.
4. Add the possibility to restart from the previous calculation.
5. Switch on smearing for metallic systems
6. Use input magnetization
7. Define total multiplicity as the function of initial atomic magnetization.