### PR TITLE
CLI: add `--previous-workchain` to `launch relax` command

### DIFF
--- a/aiida_common_workflows/cli/launch.py
+++ b/aiida_common_workflows/cli/launch.py
@@ -30,10 +30,11 @@ def cmd_launch():
 @options.WALLCLOCK_SECONDS()
 @options.DAEMON()
 @options.MAGNETIZATION_PER_SITE()
+@options.PREVIOUS_WORKCHAIN()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
 def cmd_relax(
     plugin, structure, codes, protocol, relax_type, spin_type, threshold_forces, threshold_stress, number_machines,
-    wallclock_seconds, daemon, magnetization_per_site, show_engines
+    wallclock_seconds, daemon, magnetization_per_site, previous_workchain, show_engines
 ):
     """Relax a crystal structure using the common relax workflow for one of the existing plugin implementations.
 
@@ -43,7 +44,6 @@ def cmd_relax(
     Use the `--show-engine` flag to display the required calculation engines for the selected plugin workflow.
     """
     # pylint: disable=too-many-locals
-
     process_class = load_workflow_entry_point('relax', plugin)
     generator = process_class.get_inputs_generator()
 
@@ -114,7 +114,8 @@ def cmd_relax(
         threshold_forces=threshold_forces,
         threshold_stress=threshold_stress,
         spin_type=spin_type,
-        magnetization_per_site=magnetization_per_site
+        magnetization_per_site=magnetization_per_site,
+        previous_workchain=previous_workchain,
     )
     utils.launch_process(builder, daemon)
 

--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -202,3 +202,11 @@ PRECISIONS = options.OverridableOption(
 PRINT_TABLE = options.OverridableOption(
     '-t', '--print-table', is_flag=True, help='Print the volume and energy table instead of plotting.'
 )
+
+PREVIOUS_WORKCHAIN = options.OverridableOption(
+    '-P',
+    '--previous-workchain',
+    type=types.WorkflowParamType(),
+    required=False,
+    help='An instance of a completed workchain of the same type as would be run for the given plugin.'
+)

--- a/tests/cli/test_options.py
+++ b/tests/cli/test_options.py
@@ -7,7 +7,7 @@ import click
 import pytest
 
 from aiida import orm
-from aiida_common_workflows.cli.options import StructureDataParamType
+from aiida_common_workflows.cli import options
 
 
 @pytest.fixture
@@ -21,7 +21,7 @@ def filepath_cif():
 @pytest.fixture
 def param_type():
     """Return instance of ``StructureDataParamType``."""
-    return StructureDataParamType()
+    return options.StructureDataParamType()
 
 
 class TestStructureDataParamType:
@@ -79,3 +79,15 @@ class TestStructureDataParamType:
         """
         result = param_type.convert(label, None, None)
         assert result.get_formula() == formula
+
+
+def test_previous_workchain(run_cli_command):
+    """Test the ``options.PREVIOUS_WORKCHAIN`` option."""
+    node = orm.WorkflowNode().store()
+
+    @click.command()
+    @options.PREVIOUS_WORKCHAIN()
+    def command(previous_workchain):
+        assert previous_workchain.pk == node.pk
+
+    run_cli_command(command, ['--previous-workchain', str(node.pk)])


### PR DESCRIPTION
Fixes #100 

The option allows to pass a node representing an already completed
common relax work chain of a particular plugin which should be used by
the builder to determine the inputs. The protocol's `get_builder` will
validate that the node actually corresponds to one run by the plugin
that is requested to run.

Note that the same option is not added for the other launch command
`eos` and `dissociation-curve` because there the workchain will itself
run a single workchain first that is subsequently passed to the
generator of all other workchains.