### PR TITLE
`ProtocolRegistry`: return deepcopy for `get_protocol`

### DIFF
--- a/aiida_common_workflows/protocol/registry.py
+++ b/aiida_common_workflows/protocol/registry.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unsupported-membership-test,unsubscriptable-object
 """Module with base protocol registry."""
+import copy
 import typing
 
 __all__ = ('ProtocolRegistry',)
@@ -50,6 +51,6 @@ class ProtocolRegistry:
     def get_protocol(self, name: str) -> typing.Dict:
         """Return the protocol corresponding to the given name."""
         try:
-            return self._protocols[name]
-        except KeyError:
-            raise ValueError('the protocol `{}` does not exist'.format(name))
+            return copy.deepcopy(self._protocols[name])
+        except KeyError as exception:
+            raise ValueError('the protocol `{}` does not exist'.format(name)) from exception

--- a/tests/protocol/test_registry.py
+++ b/tests/protocol/test_registry.py
@@ -90,3 +90,10 @@ def test_get_protocol(protocol_registry):
 
     with pytest.raises(ValueError):
         protocol_registry.get_protocol('non-existant')
+
+
+def test_get_protocol_immutable(protocol_registry):
+    """Test `ProtocolRegistry.get_protocol` returns a deepcopy."""
+    protocol = protocol_registry.get_protocol('efficiency')
+    protocol['description'] = 'changed description'
+    assert protocol_registry.get_protocol('efficiency')['description'] != 'changed description'


### PR DESCRIPTION
Fixes #61 

If a reference is returned, any alterations to the reference will also
affect the original protocol, which means that if it is requested a
second time in the same interpreter, it will have changed, which is
almost certainly not desirable.