### PR TITLE
Feature/get input dict

### DIFF
--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -199,7 +199,7 @@ class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):
             **kwargs
         )
 
-        return builder._inputs(prune=True)
+        return builder._inputs(prune=True)  # pylint: disable=protected-access
 
     def get_calc_types(self):
         """Return the calculation types for this input generator."""

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -151,6 +151,56 @@ class RelaxInputsGenerator(ProtocolRegistry, metaclass=ABCMeta):
             if len(magnetization_per_site) != len(structure.sites):
                 raise ValueError('An initial magnetization must be defined for each site of `structure`')
 
+    def get_input_dict(
+        self,
+        structure: StructureData,
+        calc_engines: Dict[str, Any],
+        *,
+        protocol: str = None,
+        relax_type: RelaxType = RelaxType.ATOMS,
+        electronic_type: ElectronicType = ElectronicType.METAL,
+        spin_type: SpinType = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
+        threshold_forces: float = None,
+        threshold_stress: float = None,
+        previous_workchain=None,
+        **kwargs
+    ) -> dict:
+        """Return a dictionary with inputs selected according to the protocol and that can be
+        directly unwrapped (**) into keyword arguments of the `submit`/`run` function.
+
+        :param structure: the structure to be relaxed.
+        :param calc_engines: a dictionary containing the computational resources for the relaxation.
+        :param protocol: the protocol to use when determining the workchain inputs.
+        :param relax_type: the type of relaxation to perform.
+        :param electronic_type: the electronic character that is to be used for the structure.
+        :param spin_type: the spin polarization type to use for the calculation.
+        :param magnetization_per_site: a list/tuple with the initial spin polarization for each site. Float or integer
+            in units of electrons. If not defined, the builder will automatically define the initial magnetization if
+            and only if `spin_type != SpinType.NONE`.
+        :param threshold_forces: target threshold for the forces in eV/Å.
+        :param threshold_stress: target threshold for the stress in eV/Å^3.
+        :param previous_workchain: a <Code>RelaxWorkChain node.
+        :param kwargs: any inputs that are specific to the plugin.
+        :return: a python `dict` ready to be unwrapped (**) into keyword arguments of the `submit`/`run` function.
+        """
+
+        builder = self.get_builder(
+            structure,
+            calc_engines,
+            protocol=protocol,
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
+            magnetization_per_site=magnetization_per_site,
+            threshold_forces=threshold_forces,
+            threshold_stress=threshold_stress,
+            previous_workchain=previous_workchain,
+            **kwargs
+        )
+
+        return builder._inputs(prune=True)
+
     def get_calc_types(self):
         """Return the calculation types for this input generator."""
         return list(self._calc_types.keys())


### PR DESCRIPTION
A method `get_input_dict` is added in the `InputsGenerator` abstract class.
It has the same signature of `get_builder` but it returns the inputs for the `<code>RelaxWorkChain` in a dictionary, instead of the `builder` ready to submit.
This is useful in situations when the inputs of a `<code>RelaxWorkChain`are needed in a higher level workchain that has `<code>RelaxWorkChain` as a sub-process.
In addition, it allows to explain more intuitively the concept of input generator, without the need to introduce the concept of a `builder`. In fact now, a `<code>RelaxWorkChain` can be submitted with this lines:
```
from ... import  <code>RelaxWorkChain
from aiida.engine import submit
inputs = <code>RelaxWorkChain.get_input_generator().get_input_dict(structure, calc_engines,  ...)
submit(<code>RelaxWorkChain, **inputs)
```
Which is intuitive and probably used in the upcoming paper.