### PR TITLE
End eos and dissociation workchain if first run fails

### DIFF
--- a/aiida_common_workflows/workflows/dissociation.py
+++ b/aiida_common_workflows/workflows/dissociation.py
@@ -172,6 +172,10 @@ class DissociationCurveWorkChain(WorkChain):
 
     def run_dissociation(self):
         """Run the sub process at each distance to compute the total energy."""
+        if any([not child.is_finished_ok for child in self.ctx.children]):
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=self.inputs.sub_process_class)  # pylint: disable=no-member
+
+
         for distance in self.get_distances()[1:]:
             previous_workchain = self.ctx.previous_workchain
             builder, distance_node = self.get_sub_workchain_builder(distance, previous_workchain=previous_workchain)

--- a/aiida_common_workflows/workflows/dissociation.py
+++ b/aiida_common_workflows/workflows/dissociation.py
@@ -123,6 +123,7 @@ class DissociationCurveWorkChain(WorkChain):
         spec.inputs.validator = validate_inputs
         spec.outline(
             cls.run_init,
+            cls.inspect_init,
             cls.run_dissociation,
             cls.inspect_results,
         )
@@ -170,12 +171,14 @@ class DissociationCurveWorkChain(WorkChain):
         self.ctx.previous_workchain = self.submit(builder)
         self.to_context(children=append_(self.ctx.previous_workchain))
 
-    def run_dissociation(self):
-        """Run the sub process at each distance to compute the total energy."""
-        if any([not child.is_finished_ok for child in self.ctx.children]):
+    def inspect_init(self):
+        """Check that the first workchain finished successfully or abort the workchain."""
+        if not self.ctx.children[0].is_finished_ok:
+            self.report('Initial sub process did not finish successful so aborting the workchain.')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=self.inputs.sub_process_class)  # pylint: disable=no-member
 
-
+    def run_dissociation(self):
+        """Run the sub process at each distance to compute the total energy."""
         for distance in self.get_distances()[1:]:
             previous_workchain = self.ctx.previous_workchain
             builder, distance_node = self.get_sub_workchain_builder(distance, previous_workchain=previous_workchain)

--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -144,6 +144,10 @@ class EquationOfStateWorkChain(WorkChain):
 
     def run_eos(self):
         """Run the sub process at each scale factor to compute the structure volume and total energy."""
+        
+        if any([not child.is_finished_ok for child in self.ctx.children]):
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=self.inputs.sub_process_class)  # pylint: disable=no-member
+
         for scale_factor in self.get_scale_factors()[1:]:
             previous_workchain = self.ctx.previous_workchain
             builder, structure = self.get_sub_workchain_builder(scale_factor, previous_workchain=previous_workchain)

--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -144,7 +144,7 @@ class EquationOfStateWorkChain(WorkChain):
 
     def run_eos(self):
         """Run the sub process at each scale factor to compute the structure volume and total energy."""
-        
+
         if any([not child.is_finished_ok for child in self.ctx.children]):
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=self.inputs.sub_process_class)  # pylint: disable=no-member
 


### PR DESCRIPTION
Currently we launch all further workchains, even if the init run already failed, which in the end means the wc failed.
So we waist resources.


@bosonie : maybe one can do this differently, since one expects one child at that point. But I am not sure if the child will be always there, any([]) will also be False.