### PR TITLE
Update `kpoint_spacings` in protocols

### DIFF
--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -4,7 +4,6 @@ import collections
 import copy
 import pathlib
 from typing import Any, Dict, List
-from math import pi
 import yaml
 
 from aiida import engine
@@ -194,13 +193,14 @@ class CastepRelaxInputGenerator(RelaxInputsGenerator):
         # Process electronic type
         # for plane-wave DFT density mixing is most efficient for both metal and insulators
         # these days. Here we stick to the default of CASTEP and do nothing here.
-        if electronic_type == ElectronicType.METAL:
-            # Use fine kpoints grid for all metallic calculations
-            override['base']['kpoints_spacing'] = 0.03
-        elif electronic_type in (ElectronicType.INSULATOR, ElectronicType.AUTOMATIC):
-            pass
-        else:
-            raise ValueError('Unsupported `electronic_type` {}.'.format(electronic_type))
+        #if electronic_type == ElectronicType.METAL:
+        #    # Use fine kpoints grid for all metallic calculations
+        # No need to do this since the default is spacing is sufficiently fine
+        #    override['base']['kpoints_spacing'] = 0.03
+        #elif electronic_type in (ElectronicType.INSULATOR, ElectronicType.AUTOMATIC):
+        #    pass
+        #else:
+        #    raise ValueError('Unsupported `electronic_type` {}.'.format(electronic_type))
 
         # Raise the cut off energy for very soft pseudopotentials
         # this is because the small basis set will give rise to errors in EOS / variable volume
@@ -419,7 +419,7 @@ def generate_inputs_calculation(
 
     kpoints = orm.KpointsData()
     kpoints.set_cell_from_structure(structure)
-    kpoints.set_kpoints_mesh_from_density(protocol['kpoints_spacing'] * pi * 2)
+    kpoints.set_kpoints_mesh_from_density(protocol['kpoints_spacing'])
 
     # For bare calculation level, we need to make sure the dictionary is not "flat"
     param = merged_calc['parameters']

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -3,6 +3,7 @@
 import collections
 import copy
 import pathlib
+from math import pi
 from typing import Any, Dict, List
 import yaml
 
@@ -387,7 +388,8 @@ def generate_inputs_base(
     calc_dictionary.pop('kpoints', None)
 
     dictionary = {
-        'kpoints_spacing': orm.Float(merged['kpoints_spacing']),
+        # Convert to CASTEP convention - no 2pi factor for real/reciprocal space conversion
+        'kpoints_spacing': orm.Float(merged['kpoints_spacing'] / 2 / pi),
         'max_iterations': orm.Int(merged['max_iterations']),
         'pseudos_family': orm.Str(otfg_family.label),
         'calc': calc_dictionary

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -389,6 +389,7 @@ def generate_inputs_base(
 
     dictionary = {
         # Convert to CASTEP convention - no 2pi factor for real/reciprocal space conversion
+        # This is the convention that CastepBaseWorkChain uses
         'kpoints_spacing': orm.Float(merged['kpoints_spacing'] / 2 / pi),
         'max_iterations': orm.Int(merged['max_iterations']),
         'pseudos_family': orm.Str(otfg_family.label),
@@ -419,6 +420,8 @@ def generate_inputs_calculation(
     # This merge perserves the merged `parameters` in the override
     merged_calc = recursive_merge(protocol['calc'], override)
 
+    # Create KpointData for CastepCalculation, the kpoints_spacing passed is
+    # already in the AiiDA convention, e.g. with 2pi factor built into it.
     kpoints = orm.KpointsData()
     kpoints.set_cell_from_structure(structure)
     kpoints.set_kpoints_mesh_from_density(protocol['kpoints_spacing'])

--- a/aiida_common_workflows/workflows/relax/castep/protocol.yml
+++ b/aiida_common_workflows/workflows/relax/castep/protocol.yml
@@ -65,7 +65,7 @@ fast:
             max_meta_iterations: 5
 
         base:
-            kpoints_spacing: 0.5    # Equivalent to `kpoints_mp_spacing : 0.079577`
+            kpoints_spacing: 0.25    # Equivalent to `kpoints_mp_spacing : 0.039789`
             pseudos_family: 'QC5'
             max_iterations: 5
             calc:

--- a/aiida_common_workflows/workflows/relax/castep/protocol.yml
+++ b/aiida_common_workflows/workflows/relax/castep/protocol.yml
@@ -6,7 +6,7 @@ moderate:
             max_meta_iterations: 5
 
         base:
-            kpoints_spacing: 0.04
+            kpoints_spacing: 0.15   # Note that is equivalent to kpoints_mp_spacing  : 0.023873
             pseudos_family: 'C19'
             max_iterations: 5
             calc:
@@ -35,7 +35,7 @@ precise:
             max_meta_iterations: 5
 
         base:
-            kpoints_spacing: 0.03
+            kpoints_spacing: 0.1   # Equivalent to  `kpoints_mp_spacing : 0.015915`
             pseudos_family: 'C19'
             max_iterations: 5
             calc:
@@ -65,7 +65,7 @@ fast:
             max_meta_iterations: 5
 
         base:
-            kpoints_spacing: 0.07
+            kpoints_spacing: 0.5    # Equivalent to `kpoints_mp_spacing : 0.079577`
             pseudos_family: 'QC5'
             max_iterations: 5
             calc:

--- a/tests/workflows/relax/test_castep.py
+++ b/tests/workflows/relax/test_castep.py
@@ -5,9 +5,9 @@ Tests from the generator
 # pylint: disable=abstract-method,arguments-differ,redefined-outer-name,unused-argument
 import copy
 import pytest
-from ase.build.bulk import bulk
 from aiida.orm import StructureData
 from aiida.plugins import WorkflowFactory
+from ase.build.bulk import bulk
 from aiida_castep.data.otfg import OTFGGroup
 
 from aiida_common_workflows.workflows.relax.castep.workchain import CastepRelaxWorkChain
@@ -145,7 +145,7 @@ def test_input_generator(castep_code, nacl, si):  # pylint: disable=invalid-name
     builder = gen.get_builder(si, calc_engines, protocol='moderate')
     param = builder.calc.parameters.get_dict()
     assert param['cut_off_energy'] == 326
-    assert builder.base.kpoints_spacing == 0.03
+    assert builder.base.kpoints_spacing == pytest.approx(0.023873, abs=1e-6)
 
     builder = gen.get_builder(si, calc_engines, protocol='moderate', relax_type=RelaxType.ATOMS)
     assert 'fix_all_cell' in builder.calc.parameters.get_dict()
@@ -161,4 +161,4 @@ def test_input_generator(castep_code, nacl, si):  # pylint: disable=invalid-name
 
     builder = gen.get_builder(si, calc_engines, protocol='moderate', electronic_type=ElectronicType.INSULATOR)
     assert builder.calc.settings is None
-    assert builder.base.kpoints_spacing == 0.04
+    assert builder.base.kpoints_spacing == pytest.approx(0.023873, abs=1e-6)


### PR DESCRIPTION
The k-points spacings for CASTEP protocols are now changed to:

- 0.1 for precise
- 0.15 for moderate
- 0.5 for fast

These values are in the AiiDA's convention where the 2pi factor is included in the values.  