### PR TITLE
Rename `RelaxType.ATOMS` to `RelaxType.POSITIONS`

### DIFF
--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -126,7 +126,7 @@ RELAX_TYPE = options.OverridableOption(
     '-r',
     '--relax-type',
     type=types.LazyChoice(get_relax_types),
-    default='atoms',
+    default='positions',
     show_default=True,
     callback=lambda ctx, param, value: RelaxType(value),
     help='Select the relax type with which the workflow should be run.'

--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -49,7 +49,7 @@ def validate_scale_increment(value, _):
 
 def validate_relax_type(value, _):
     """Validate the `generator_inputs.relax_type` input."""
-    if value not in [RelaxType.NONE, RelaxType.ATOMS, RelaxType.SHAPE, RelaxType.ATOMS_SHAPE]:
+    if value not in [RelaxType.NONE, RelaxType.POSITIONS, RelaxType.SHAPE, RelaxType.POSITIONS_SHAPE]:
         return '`generator_inputs.relax_type`. Equation of state and relaxation with variable volume not compatible.'
 
 

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -26,10 +26,10 @@ class AbinitRelaxInputGenerator(RelaxInputGenerator):
     _engine_types = {'relax': {'code_plugin': 'abinit', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
         RelaxType.NONE: 'Fix the atomic positions, cell volume, and cell shape.',
-        RelaxType.ATOMS: 'Relax the atomic positions at fixed cell volume and shape.',
-        RelaxType.ATOMS_CELL: 'Relax the atomic positions, cell volume, and cell shape.',
-        RelaxType.ATOMS_VOLUME: 'Relax the atomic positions and cell volume at fixed cell shape.',
-        RelaxType.ATOMS_SHAPE: 'Relax the atomic positions and cell shape at fixed cell volume.'
+        RelaxType.POSITIONS: 'Relax the atomic positions at fixed cell volume and shape.',
+        RelaxType.POSITIONS_CELL: 'Relax the atomic positions, cell volume, and cell shape.',
+        RelaxType.POSITIONS_VOLUME: 'Relax the atomic positions and cell volume at fixed cell shape.',
+        RelaxType.POSITIONS_SHAPE: 'Relax the atomic positions and cell shape at fixed cell volume.'
     }
     _spin_types = {
         SpinType.NONE: 'Do not enable any magnetization or spin-orbit coupling.',
@@ -59,7 +59,7 @@ class AbinitRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,
@@ -186,16 +186,16 @@ class AbinitRelaxInputGenerator(RelaxInputGenerator):
         # RelaxType
         if relax_type == RelaxType.NONE:
             builder.abinit['parameters']['ionmov'] = 0  # do not move the ions, Abinit default
-        elif relax_type == RelaxType.ATOMS:
-            # protocol defaults to ATOMS
+        elif relax_type == RelaxType.POSITIONS:
+            # protocol defaults to POSITIONS
             pass
-        elif relax_type == RelaxType.ATOMS_CELL:
+        elif relax_type == RelaxType.POSITIONS_CELL:
             builder.abinit['parameters']['optcell'] = 2  # fully optimize the cell geometry
             builder.abinit['parameters']['dilatmx'] = 1.15  # book additional mem. for p.w. basis exp.
-        elif relax_type == RelaxType.ATOMS_VOLUME:
+        elif relax_type == RelaxType.POSITIONS_VOLUME:
             builder.abinit['parameters']['optcell'] = 1  # optimize volume only
             builder.abinit['parameters']['dilatmx'] = 1.15  # book additional mem. for p.w. basis exp.
-        elif relax_type == RelaxType.ATOMS_SHAPE:
+        elif relax_type == RelaxType.POSITIONS_SHAPE:
             builder.abinit['parameters']['optcell'] = 3  # constant-volume optimization of cell geometry
             builder.abinit['parameters']['dilatmx'] = 1.05  # book additional mem. for p.w. basis exp.
         else:

--- a/aiida_common_workflows/workflows/relax/bigdft/generator.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/generator.py
@@ -148,7 +148,7 @@ class BigDftRelaxInputGenerator(RelaxInputGenerator):
     _engine_types = {'relax': {'code_plugin': 'bigdft', 'description': 'The code to perform the relaxation.'}}
 
     _relax_types = {
-        RelaxType.ATOMS: 'Relax only the atomic positions while keeping the cell fixed.',
+        RelaxType.POSITIONS: 'Relax only the atomic positions while keeping the cell fixed.',
         RelaxType.NONE: 'No relaxation'
     }
     _spin_types = {SpinType.NONE: 'nspin : 1', SpinType.COLLINEAR: 'nspin: 2'}
@@ -163,7 +163,7 @@ class BigDftRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,
@@ -208,7 +208,7 @@ class BigDftRelaxInputGenerator(RelaxInputGenerator):
 
         builder = self.process_class.get_builder()
 
-        if relax_type == RelaxType.ATOMS:
+        if relax_type == RelaxType.POSITIONS:
             relaxation_schema = 'relax'
         elif relax_type == RelaxType.NONE:
             relaxation_schema = 'relax'

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -28,10 +28,11 @@ class CastepRelaxInputGenerator(RelaxInputGenerator):
     _default_protocol = 'moderate'
     _engine_types = {'relax': {'code_plugin': 'castep.castep', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
-        RelaxType.ATOMS: 'Relax only the atomic positions while keeping the cell fixed.',
-        RelaxType.ATOMS_CELL: 'Relax both atomic positions and the cell.',
-        RelaxType.ATOMS_SHAPE: 'Relax both atomic positions and the shape of the cell, keeping the volume fixed.',
-        RelaxType.ATOMS_VOLUME: 'Relax both atomic positions and the volume of the cell, keeping the cell shape fixed.',
+        RelaxType.POSITIONS: 'Relax only the atomic positions while keeping the cell fixed.',
+        RelaxType.POSITIONS_CELL: 'Relax both atomic positions and the cell.',
+        RelaxType.POSITIONS_SHAPE: 'Relax both atomic positions and the shape of the cell, keeping the volume fixed.',
+        RelaxType.POSITIONS_VOLUME:
+        'Relax both atomic positions and the volume of the cell, keeping the cell shape fixed.',
         RelaxType.NONE: 'Do not do any relaxation.',
         RelaxType.CELL: 'Only relax the cell with the scaled positions of atoms are kept fixed.',
         RelaxType.SHAPE: 'Only relax the shape of the cell.',
@@ -69,7 +70,7 @@ class CastepRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,
@@ -129,14 +130,14 @@ class CastepRelaxInputGenerator(RelaxInputGenerator):
             param['geom_stress_tol'] = threshold_stress * ev_to_gpa
 
         # Assign relaxation types
-        if relax_type == RelaxType.ATOMS:
+        if relax_type == RelaxType.POSITIONS:
             param['fix_all_cell'] = True
-        elif relax_type == RelaxType.ATOMS_CELL:
+        elif relax_type == RelaxType.POSITIONS_CELL:
             pass
-        elif relax_type == RelaxType.ATOMS_VOLUME:
+        elif relax_type == RelaxType.POSITIONS_VOLUME:
             # Use cell constraints to tie the lattice parameters fix angles
             param['cell_constraints'] = ['1 1 1', '0 0 0']
-        elif relax_type == RelaxType.ATOMS_SHAPE:
+        elif relax_type == RelaxType.POSITIONS_SHAPE:
             param['fix_vol'] = True
             # Use TPSD optimiser since LBFGS typically has slow convergence when
             # cell constraint is applied

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -136,8 +136,8 @@ class Cp2kRelaxInputGenerator(RelaxInputGenerator):
     _engine_types = {'relax': {'code_plugin': 'cp2k', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
         RelaxType.NONE: 'No relaxation performed.',
-        RelaxType.ATOMS: 'Relax only the atomic positions while keeping the cell fixed.',
-        RelaxType.ATOMS_CELL: 'Relax both atomic positions and the cell.'
+        RelaxType.POSITIONS: 'Relax only the atomic positions while keeping the cell fixed.',
+        RelaxType.POSITIONS_CELL: 'Relax both atomic positions and the cell.'
     }
     _spin_types = {
         SpinType.NONE: 'Non magnetic calculation.',
@@ -164,7 +164,7 @@ class Cp2kRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,
@@ -266,9 +266,9 @@ class Cp2kRelaxInputGenerator(RelaxInputGenerator):
         dict_merge(parameters, get_kinds_section(structure, magnetization_tags))
 
         ## Relaxation type.
-        if relax_type == RelaxType.ATOMS:
+        if relax_type == RelaxType.POSITIONS:
             run_type = 'GEO_OPT'
-        elif relax_type == RelaxType.ATOMS_CELL:
+        elif relax_type == RelaxType.POSITIONS_CELL:
             run_type = 'CELL_OPT'
         elif relax_type == RelaxType.NONE:
             run_type = 'ENERGY_FORCE'

--- a/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -46,8 +46,8 @@ class FleurRelaxInputGenerator(RelaxInputGenerator):
 
     _relax_types = {
         RelaxType.NONE: 'Do not relax forces, just run a SCF workchain.',
-        RelaxType.ATOMS: 'Relax only the atomic positions while keeping the cell fixed.'
-        # RelaxType.ATOMS_CELL: 'Relax both atomic positions and the cell.'
+        RelaxType.POSITIONS: 'Relax only the atomic positions while keeping the cell fixed.'
+        # RelaxType.POSITIONS_CELL: 'Relax both atomic positions and the cell.'
         # currently not supported by Fleur
     }
     _spin_types = {
@@ -75,7 +75,7 @@ class FleurRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,
@@ -178,7 +178,7 @@ class FleurRelaxInputGenerator(RelaxInputGenerator):
         parameters = None
 
         # Relax type options
-        if relax_type == RelaxType.ATOMS:
+        if relax_type == RelaxType.POSITIONS:
             relaxation_mode = 'force'
         elif relax_type == RelaxType.NONE:
             relaxation_mode = 'force'

--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -60,7 +60,7 @@ class GaussianRelaxInputGenerator(RelaxInputGenerator):
     _engine_types = {'relax': {'code_plugin': 'gaussian', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
         RelaxType.NONE: 'Single point calculation.',
-        RelaxType.ATOMS: 'Relax only the atomic positions while keeping the cell fixed.',
+        RelaxType.POSITIONS: 'Relax only the atomic positions while keeping the cell fixed.',
     }
     _spin_types = {
         SpinType.NONE: 'Restricted Kohn-Sham calculation',
@@ -74,7 +74,7 @@ class GaussianRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -17,13 +17,13 @@ class RelaxType(Enum):
     """Enumeration of known relax types."""
 
     NONE = 'none'
-    ATOMS = 'atoms'
+    POSITIONS = 'positions'
     VOLUME = 'volume'
     SHAPE = 'shape'
     CELL = 'cell'
-    ATOMS_CELL = 'atoms_cell'
-    ATOMS_VOLUME = 'atoms_volume'
-    ATOMS_SHAPE = 'atoms_shape'
+    POSITIONS_CELL = 'positions_cell'
+    POSITIONS_VOLUME = 'positions_volume'
+    POSITIONS_SHAPE = 'positions_shape'
 
 
 class SpinType(Enum):
@@ -102,7 +102,7 @@ class RelaxInputGenerator(ProtocolRegistry, metaclass=ABCMeta):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: Union[List[float], Tuple[float]] = None,

--- a/aiida_common_workflows/workflows/relax/orca/generator.py
+++ b/aiida_common_workflows/workflows/relax/orca/generator.py
@@ -27,7 +27,7 @@ class OrcaRelaxInputGenerator(RelaxInputGenerator):
     _engine_types = {'relax': {'code_plugin': 'orca_main', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
         RelaxType.NONE: 'Single Point Calculation',
-        RelaxType.ATOMS: 'Relaxing the geometry of molecule',
+        RelaxType.POSITIONS: 'Relaxing the geometry of molecule',
     }
     _spin_types = {
         SpinType.NONE: 'Restricted Kohn-Sham Calculation',
@@ -63,7 +63,7 @@ class OrcaRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -53,7 +53,7 @@ class QuantumEspressoRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,

--- a/aiida_common_workflows/workflows/relax/siesta/generator.py
+++ b/aiida_common_workflows/workflows/relax/siesta/generator.py
@@ -33,10 +33,10 @@ class SiestaRelaxInputGenerator(RelaxInputGenerator):
     }
     _relax_types = {
         RelaxType.NONE: 'no relaxation performed',
-        RelaxType.ATOMS: 'latice shape and volume fixed, only atomic positions are relaxed',
-        RelaxType.ATOMS_CELL: 'lattice relaxed together with atomic coordinates. Allows '
+        RelaxType.POSITIONS: 'latice shape and volume fixed, only atomic positions are relaxed',
+        RelaxType.POSITIONS_CELL: 'lattice relaxed together with atomic coordinates. Allows '
         'to target hydro-static pressures or arbitrary stress tensors.',
-        RelaxType.ATOMS_SHAPE: 'relaxation at constant volume.'
+        RelaxType.POSITIONS_SHAPE: 'relaxation at constant volume.'
     }
     _spin_types = {
         SpinType.NONE: 'non magnetic calculation',
@@ -90,7 +90,7 @@ class SiestaRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,
@@ -160,9 +160,9 @@ class SiestaRelaxInputGenerator(RelaxInputGenerator):
         if relax_type != RelaxType.NONE:
             parameters['md-type-of-run'] = 'cg'
             parameters['md-num-cg-steps'] = 100
-        if relax_type == RelaxType.ATOMS_CELL:
+        if relax_type == RelaxType.POSITIONS_CELL:
             parameters['md-variable-cell'] = True
-        if relax_type == RelaxType.ATOMS_SHAPE:
+        if relax_type == RelaxType.POSITIONS_SHAPE:
             parameters['md-variable-cell'] = True
             parameters['md-constant-volume'] = True
         if threshold_forces:

--- a/aiida_common_workflows/workflows/relax/vasp/generator.py
+++ b/aiida_common_workflows/workflows/relax/vasp/generator.py
@@ -24,12 +24,12 @@ class VaspRelaxInputGenerator(RelaxInputGenerator):
     _engine_types = {'relax': {'code_plugin': 'vasp.vasp', 'description': 'The code to perform the relaxation.'}}
     _relax_types = {
         RelaxType.NONE: 'Do not perform relaxation',
-        RelaxType.ATOMS: 'Relax only the atomic positions.',
+        RelaxType.POSITIONS: 'Relax only the atomic positions.',
         RelaxType.CELL: 'Relax only the cell (shape and volume).',
         RelaxType.SHAPE: 'Relax only the cell shape.',
         RelaxType.VOLUME: 'Relax only the cell volume.',
-        RelaxType.ATOMS_SHAPE: 'Relax both atomic positions and the cell shape.',
-        RelaxType.ATOMS_CELL: 'Relax both atomic positions and the cell (shape and volume), meaning everything.'
+        RelaxType.POSITIONS_SHAPE: 'Relax both atomic positions and the cell shape.',
+        RelaxType.POSITIONS_CELL: 'Relax both atomic positions and the cell (shape and volume), meaning everything.'
     }
     _spin_types = {SpinType.NONE: 'Non spin polarized.', SpinType.COLLINEAR: 'Spin polarized (collinear).'}
     _electronic_types = {ElectronicType.METAL: 'Not used.', ElectronicType.INSULATOR: 'Not used.'}
@@ -56,7 +56,7 @@ class VaspRelaxInputGenerator(RelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.ATOMS,
+        relax_type: RelaxType = RelaxType.POSITIONS,
         electronic_type: ElectronicType = ElectronicType.METAL,
         spin_type: SpinType = SpinType.NONE,
         magnetization_per_site: List[float] = None,
@@ -185,7 +185,7 @@ class VaspRelaxInputGenerator(RelaxInputGenerator):
             relax.perform = plugins.DataFactory('bool')(True)
             relax.algo = plugins.DataFactory('str')(protocol['relax']['algo'])
             relax.steps = plugins.DataFactory('int')(protocol['relax']['steps'])
-            if relax_type == RelaxType.ATOMS:
+            if relax_type == RelaxType.POSITIONS:
                 relax.positions = plugins.DataFactory('bool')(True)
                 relax.shape = plugins.DataFactory('bool')(False)
                 relax.volume = plugins.DataFactory('bool')(False)
@@ -201,11 +201,11 @@ class VaspRelaxInputGenerator(RelaxInputGenerator):
                 relax.positions = plugins.DataFactory('bool')(False)
                 relax.shape = plugins.DataFactory('bool')(True)
                 relax.volume = plugins.DataFactory('bool')(False)
-            elif relax_type == RelaxType.ATOMS_CELL:
+            elif relax_type == RelaxType.POSITIONS_CELL:
                 relax.positions = plugins.DataFactory('bool')(True)
                 relax.shape = plugins.DataFactory('bool')(True)
                 relax.volume = plugins.DataFactory('bool')(True)
-            elif relax_type == RelaxType.ATOMS_SHAPE:
+            elif relax_type == RelaxType.POSITIONS_SHAPE:
                 relax.positions = plugins.DataFactory('bool')(True)
                 relax.shape = plugins.DataFactory('bool')(True)
                 relax.volume = plugins.DataFactory('bool')(False)

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -96,7 +96,7 @@ def test_eos_relax_types(run_cli_command, generate_structure, generate_code):
     options = ['-S', str(structure.pk), '-r', 'cell', 'quantum_espresso']
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
     assert "Error: Invalid value for '-r' / '--relax-type': invalid choice: cell. " \
-            '(choose from none, atoms, shape, atoms_shape)' in result.output_lines
+            '(choose from none, positions, shape, positions_shape)' in result.output_lines
 
 
 @pytest.mark.usefixtures('aiida_profile')

--- a/tests/workflows/relax/test_castep.py
+++ b/tests/workflows/relax/test_castep.py
@@ -147,10 +147,10 @@ def test_input_generator(castep_code, nacl, si):  # pylint: disable=invalid-name
     assert param['cut_off_energy'] == 326
     assert builder.base.kpoints_spacing == pytest.approx(0.023873, abs=1e-6)
 
-    builder = gen.get_builder(si, engines, protocol='moderate', relax_type=RelaxType.ATOMS)
+    builder = gen.get_builder(si, engines, protocol='moderate', relax_type=RelaxType.POSITIONS)
     assert 'fix_all_cell' in builder.calc.parameters.get_dict()
 
-    builder = gen.get_builder(si, engines, protocol='moderate', relax_type=RelaxType.ATOMS_SHAPE)
+    builder = gen.get_builder(si, engines, protocol='moderate', relax_type=RelaxType.POSITIONS_SHAPE)
     assert 'fix_vol' in builder.calc.parameters.get_dict()
 
     builder = gen.get_builder(si, engines, protocol='moderate', spin_type=SpinType.COLLINEAR)

--- a/tests/workflows/relax/test_generator.py
+++ b/tests/workflows/relax/test_generator.py
@@ -31,8 +31,8 @@ def inputs_generator(protocol_registry) -> RelaxInputGenerator:
         _engine_types = {'relax': {'code_plugin': 'entry.point', 'description': 'test'}}
 
         _relax_types = {
-            RelaxType.ATOMS: 'Relax only the atomic positions while keeping the cell fixed.',
-            RelaxType.ATOMS_CELL: 'Relax both atomic positions and the cell.'
+            RelaxType.POSITIONS: 'Relax only the atomic positions while keeping the cell fixed.',
+            RelaxType.POSITIONS_CELL: 'Relax both atomic positions and the cell.'
         }
 
         _spin_types = {SpinType.NONE: '...', SpinType.COLLINEAR: '...'}
@@ -66,7 +66,7 @@ def test_validation(protocol_registry):
         """Invalid input generator implementation: no process class passed."""
 
         _engine_types = {'relax': {}}
-        _relax_types = {RelaxType.ATOMS: 'description'}
+        _relax_types = {RelaxType.POSITIONS: 'description'}
 
         def get_builder(self):
             pass
@@ -92,7 +92,7 @@ def test_validation(protocol_registry):
         """Invalid input generator implementation: no ``_engine_types``"""
 
         _engine_types = None
-        _relax_types = {RelaxType.ATOMS: 'description'}
+        _relax_types = {RelaxType.POSITIONS: 'description'}
         _spin_types = {SpinType.NONE: '...', SpinType.COLLINEAR: '...'}
         _electronic_types = {ElectronicType.INSULATOR: '...', ElectronicType.METAL: '...'}
 
@@ -106,7 +106,7 @@ def test_validation(protocol_registry):
         """Invalid input generator implementation: no ``_spin_types``"""
 
         _engine_types = {'relax': {}}
-        _relax_types = {RelaxType.ATOMS: 'description'}
+        _relax_types = {RelaxType.POSITIONS: 'description'}
         _spin_types = None
         _electronic_types = {ElectronicType.INSULATOR: '...', ElectronicType.METAL: '...'}
 
@@ -120,7 +120,7 @@ def test_validation(protocol_registry):
         """Invalid input generator implementation: no ``_electronic_types``"""
 
         _engine_types = {'relax': {}}
-        _relax_types = {RelaxType.ATOMS: 'description'}
+        _relax_types = {RelaxType.POSITIONS: 'description'}
         _spin_types = {SpinType.NONE: '...', SpinType.COLLINEAR: '...'}
         _electronic_types = None
 
@@ -148,7 +148,7 @@ def test_validation(protocol_registry):
         """Invalid input generator implementation: invalid ``_spin_types``"""
 
         _engine_types = {'relax': {}}
-        _relax_types = {RelaxType.ATOMS: 'description'}
+        _relax_types = {RelaxType.POSITIONS: 'description'}
         _spin_types = {'invalid-type': 'description'}
         _electronic_types = {ElectronicType.INSULATOR: '...', ElectronicType.METAL: '...'}
 
@@ -162,7 +162,7 @@ def test_validation(protocol_registry):
         """Invalid input generator implementation: invalid ``_electronic_types``"""
 
         _engine_types = {'relax': {}}
-        _relax_types = {RelaxType.ATOMS: 'description'}
+        _relax_types = {RelaxType.POSITIONS: 'description'}
         _spin_types = {SpinType.NONE: '...', SpinType.COLLINEAR: '...'}
         _electronic_types = {'invalid_type': '...'}
 
@@ -185,7 +185,7 @@ def test_get_engine_type_schema(inputs_generator):
 
 def test_get_relax_types(inputs_generator):
     """Test `RelaxInputGenerator.get_relax_types`."""
-    assert set(inputs_generator.get_relax_types()) == {RelaxType.ATOMS, RelaxType.ATOMS_CELL}
+    assert set(inputs_generator.get_relax_types()) == {RelaxType.POSITIONS, RelaxType.POSITIONS_CELL}
 
 
 def test_get_spin_types(inputs_generator):


### PR DESCRIPTION
Fixes #144 

The same goes for the other enum keys starting with `ATOMS_` and the
string value `atoms` is also renamed to `positions`. The reason is that
one relaxes atomic positions and not the atoms themselves.