### PR TITLE
Update the plugin requirements

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -16,14 +16,14 @@
     "python_requires": ">=3.6",
     "install_requires": [
         "abipy",
-        "aiida-abinit~=0.2.0a0",
+        "aiida-abinit~=0.2.0a1",
         "ase==3.19",
         "aiida-core[atomic_tools]~=1.2",
         "aiida-bigdft>=0.2.4",
         "aiida-cp2k~=1.3",
         "aiida-fleur>=1.1.3",
         "aiida-gaussian",
-        "aiida-quantumespresso~=3.3",
+        "aiida-quantumespresso~=3.3,>=3.3.1",
         "aiida-siesta~=1.1",
         "aiida-castep>=1.2.0a5",
         "aiida-vasp",
@@ -48,16 +48,16 @@
         "aiida.workflows": [
             "common_workflows.eos = aiida_common_workflows.workflows.eos:EquationOfStateWorkChain",
             "common_workflows.dissociation_curve = aiida_common_workflows.workflows.dissociation:DissociationCurveWorkChain",
+            "common_workflows.relax.abinit = aiida_common_workflows.workflows.relax.abinit.workchain:AbinitRelaxWorkChain",
             "common_workflows.relax.bigdft = aiida_common_workflows.workflows.relax.bigdft.workchain:BigDftRelaxWorkChain",
+            "common_workflows.relax.castep = aiida_common_workflows.workflows.relax.castep.workchain:CastepRelaxWorkChain",
             "common_workflows.relax.cp2k = aiida_common_workflows.workflows.relax.cp2k.workchain:Cp2kRelaxWorkChain",
             "common_workflows.relax.fleur = aiida_common_workflows.workflows.relax.fleur.workchain:FleurRelaxWorkChain",
             "common_workflows.relax.gaussian = aiida_common_workflows.workflows.relax.gaussian.workchain:GaussianRelaxWorkChain",
+            "common_workflows.relax.orca = aiida_common_workflows.workflows.relax.orca.workchain:OrcaRelaxWorkChain",
             "common_workflows.relax.quantum_espresso = aiida_common_workflows.workflows.relax.quantum_espresso.workchain:QuantumEspressoRelaxWorkChain",
             "common_workflows.relax.siesta = aiida_common_workflows.workflows.relax.siesta.workchain:SiestaRelaxWorkChain",
-            "common_workflows.relax.vasp = aiida_common_workflows.workflows.relax.vasp.workchain:VaspRelaxWorkChain",
-            "common_workflows.relax.castep = aiida_common_workflows.workflows.relax.castep.workchain:CastepRelaxWorkChain",
-            "common_workflows.relax.abinit = aiida_common_workflows.workflows.relax.abinit.workchain:AbinitRelaxWorkChain",
-            "common_workflows.relax.orca = aiida_common_workflows.workflows.relax.orca.workchain:OrcaRelaxWorkChain"
+            "common_workflows.relax.vasp = aiida_common_workflows.workflows.relax.vasp.workchain:VaspRelaxWorkChain"
         ]
     },
     "license": "MIT License",


### PR DESCRIPTION
 * `aiida-abinit` updated to latest alpha release
 * `aiida-quantumespresso` updated to require at least `v3.3.1` because
   this updates its requirement for `aiida-pseudo` which was different
   from that of `aiida-abinit` causing a conflict. Both now require
   `aiida-pseudo~=0.5.0`