### PR TITLE
Fix assigning magnetic moments

### DIFF
--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -101,9 +101,9 @@ class QuantumEspressoRelaxInputGenerator(RelaxInputGenerator):
         )
 
         if magnetization_per_site:
-            kind_to_magnetization = zip([site.kind_name for site in structure.sites], magnetization_per_site)
+            kind_to_magnetization = set(zip([site.kind_name for site in structure.sites], magnetization_per_site))
 
-            if len(structure.kinds) != len(set(kind_to_magnetization)):
+            if len(structure.kinds) != len(kind_to_magnetization):
                 raise ValueError(
                     'the provided `magnetization_per_site` requires the structure to have different kinds, which would '
                     'require changing the structure, which is not yet supported. Either manually adapt the structure '


### PR DESCRIPTION
Currently the `QuantumEspressoRelaxInputGenerator` fails to assign the
correct magnetic moments based on the `magnetization_per_site` input.
The reason is that the `zip` generator is exhausted by the conversion
into a `set` when comparing the kinds of the structure with the mapping
of the kinds to the magnetic moments provided. Hence, the `dict`
assigned to the `initial_magnetic_moments` variable will be empty.

For example:

```Python
In [1]: l1 = ('a', 'b'); l2 = (1, 2); z1 = zip(l1, l2)

In [2]: set(z1)
Out[2]: {('a', 1), ('b', 2)}

In [3]: dict(z1)
Out[3]: {}
```

Thanks to @yakutovicha for reporting this issue!