### PR TITLE
Add `create_magnetic_allotrope` function

### DIFF
--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -119,7 +119,9 @@ class CommonRelaxInputGenerator(ProtocolRegistry, metaclass=ABCMeta):
             if not isinstance(magnetization_per_site, (list, tuple)):
                 raise ValueError('The `initial_magnetization` must be a list or a tuple')
             if len(magnetization_per_site) != len(structure.sites):
-                raise ValueError('An initial magnetization must be defined for each site of `structure`')
+                raise ValueError(
+                    'The size of `magnetization_per_site` is different from the number of sites in `structure`.'
+                )
 
     def get_engine_types(self):
         """Return the calculation types for this input generator."""

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -44,22 +44,20 @@ def create_magnetic_allotrope(structure, magnetization_per_site):
                 f'{element}. This is currently not supported to due the character limit for kind names in Quantum '
                 'ESPRESSO.'
             )
-        elif len(magnetic_moment_set) == 1:
+        if len(magnetic_moment_set) == 1:
             magnetic_moment_kinds = {element_magnetic_moments[0]: element}
         else:
             magnetic_moment_kinds = {
                 magmom: f'{element}{index}' for magmom, index in zip(magnetic_moment_set, string.digits)
             }
         for site, magnetic_moment in zip(element_sites, element_magnetic_moments):
-           allotrope.append_atom(
+            allotrope.append_atom(
                 name=magnetic_moment_kinds[magnetic_moment],
                 symbols=(element,),
                 weights=(1.0,),
                 position=site.position,
             )
-        allotrope_magnetic_moments.update(
-            {kind_name: magmom for magmom, kind_name in magnetic_moment_kinds.items()}
-        )
+        allotrope_magnetic_moments.update({kind_name: magmom for magmom, kind_name in magnetic_moment_kinds.items()})
 
     return (allotrope, allotrope_magnetic_moments)
 

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -15,11 +15,14 @@ StructureData = plugins.DataFactory('structure')
 
 
 def create_magnetic_allotrope(structure, magnetic_moment_per_site):
-    """Create a new magnetic allotrope from the given structure based on a list of magnetic moments per site."""
+    """Create new structure with the correct magnetic kinds based on the magnetization per site
+
+    :param structure: StructureData for which to create the new kinds.
+    :param magnetization_per_site: List of magnetizations (defined as magnetic moments) for each site in the provided
+        `structure`.
+    """
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     import string
-    from aiida.orm import Dict, StructureData
-
     if structure.is_alloy:
         raise ValueError('Alloys are currently not supported.')
 

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -14,7 +14,7 @@ __all__ = ('QuantumEspressoCommonRelaxInputGenerator',)
 StructureData = plugins.DataFactory('structure')
 
 
-def create_magnetic_allotrope(structure, magnetic_moment_per_site):
+def create_magnetic_allotrope(structure, magnetization_per_site):
     """Create new structure with the correct magnetic kinds based on the magnetization per site
 
     :param structure: StructureData for which to create the new kinds.
@@ -34,7 +34,7 @@ def create_magnetic_allotrope(structure, magnetic_moment_per_site):
         # Filter the sites and magnetic moments on the site element
         element_sites, element_magnetic_moments = zip(
             *[(site, magnetic_moment)
-              for site, magnetic_moment in zip(structure.sites, magnetic_moment_per_site)
+              for site, magnetic_moment in zip(structure.sites, magnetization_per_site)
               if site.kind_name.rstrip(string.digits) == element]
         )
 
@@ -68,7 +68,7 @@ def create_magnetic_allotrope(structure, magnetic_moment_per_site):
                 position=site.position,
             )
 
-    return {'allotrope': allotrope, 'magnetic_moments': allotrope_magnetic_moments}
+    return (allotrope, allotrope_magnetic_moments)
 
 
 class QuantumEspressoCommonRelaxInputGenerator(CommonRelaxInputGenerator):

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -44,9 +44,12 @@ def create_magnetic_allotrope(structure, magnetization_per_site):
                 f'{element}. This is currently not supported to due the character limit for kind names in Quantum '
                 'ESPRESSO.'
             )
-        magnetic_moment_kinds = {
-            magmom: f'{element}{index}' for magmom, index in zip(magnetic_moment_set, string.digits)
-        }
+        elif len(magnetic_moment_set) == 1:
+            magnetic_moment_kinds = {element_magnetic_moments[0]: element}
+        else:
+            magnetic_moment_kinds = {
+                magmom: f'{element}{index}' for magmom, index in zip(magnetic_moment_set, string.digits)
+            }
         for site, magnetic_moment in zip(element_sites, element_magnetic_moments):
            allotrope.append_atom(
                 name=magnetic_moment_kinds[magnetic_moment],
@@ -54,12 +57,9 @@ def create_magnetic_allotrope(structure, magnetization_per_site):
                 weights=(1.0,),
                 position=site.position,
             )
-        if len(magnetic_moment_kinds) == 1:
-            allotrope_magnetic_moments.update({element: element_magnetic_moments[0]})
-        else:
-            allotrope_magnetic_moments.update(
-                {kind_name: magmom for magmom, kind_name in magnetic_moment_kinds.items()}
-            )
+        allotrope_magnetic_moments.update(
+            {kind_name: magmom for magmom, kind_name in magnetic_moment_kinds.items()}
+        )
 
     return (allotrope, allotrope_magnetic_moments)
 


### PR DESCRIPTION
Fixes #154 

Currently running antiferromagnetic configurations with Quantum ESPRESSO
requires that the user first creates a new structure with the necessary
kinds. This is not trivial if the user has no experience in using AIIDA.

Here we add the `create_magnetic_allotrope` function, largely based on
the CP2K variant `tags_and_magnetization`, but with some minor
adjustments to make it work properly for Quantum ESPRESSO. This function
is called when the `get_builder` method of the
`QuantumEspressoRelaxInputGenerator` notices that the provided
`magnetization_per_site` would require new kinds in the provided
`structure`.

Note that a disadvantage of this approach is that a new (possibly
duplicate) `StructureData` is created every time the `get_builder` is
called. However, this would only be stored if the returned builder is
actually run/submitted. Moreover, for more complex structures/magnetic
configurations, this would lead to kind names with 4 characters, which
is currently not supported by Quantum ESPRESSO (max 3).