### PR TITLE
Relax workflow: give all implementations same suffix

### DIFF
--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -22,7 +22,7 @@ StructureData = plugins.DataFactory('structure')
 
 
 class AbinitRelaxInputGenerator(RelaxInputGenerator):
-    """Input generator for the `AbinitRelaxWorkChain`."""
+    """Input generator for the `AbinitCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
     _engine_types = {'relax': {'code_plugin': 'abinit', 'description': 'The code to perform the relaxation.'}}
@@ -83,7 +83,7 @@ class AbinitRelaxInputGenerator(RelaxInputGenerator):
             only if `spin_type != SpinType.NONE`.
         :param threshold_forces: target threshold for the forces in eV/Å.
         :param threshold_stress: target threshold for the stress in eV/Å^3.
-        :param reference_workchain: a <Code>RelaxWorkChain node.
+        :param reference_workchain: a <Code>CommonRelaxWorkChain node.
         :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for ABINIT."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for ABINIT."""
 import collections
 import copy
 import pathlib
@@ -14,14 +14,14 @@ from aiida import engine, orm, plugins
 from aiida.common import exceptions
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('AbinitRelaxInputGenerator',)
+__all__ = ('AbinitCommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')
 
 
-class AbinitRelaxInputGenerator(RelaxInputGenerator):
+class AbinitCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `AbinitCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'

--- a/aiida_common_workflows/workflows/relax/abinit/workchain.py
+++ b/aiida_common_workflows/workflows/relax/abinit/workchain.py
@@ -8,7 +8,7 @@ from aiida.common import exceptions
 from aiida_abinit.workflows.base import AbinitBaseWorkChain
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import AbinitRelaxInputGenerator
+from .generator import AbinitCommonRelaxInputGenerator
 
 __all__ = ('AbinitCommonRelaxWorkChain',)
 
@@ -45,7 +45,7 @@ class AbinitCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Abinit."""
 
     _process_class = AbinitBaseWorkChain
-    _generator_class = AbinitRelaxInputGenerator
+    _generator_class = AbinitCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/abinit/workchain.py
+++ b/aiida_common_workflows/workflows/relax/abinit/workchain.py
@@ -10,7 +10,7 @@ from aiida_abinit.workflows.base import AbinitBaseWorkChain
 from ..workchain import CommonRelaxWorkChain
 from .generator import AbinitRelaxInputGenerator
 
-__all__ = ('AbinitRelaxWorkChain',)
+__all__ = ('AbinitCommonRelaxWorkChain',)
 
 
 @calcfunction
@@ -41,7 +41,7 @@ def get_total_magnetization(parameters):
     return orm.Float(parameters['total_magnetization'])
 
 
-class AbinitRelaxWorkChain(CommonRelaxWorkChain):
+class AbinitCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Abinit."""
 
     _process_class = AbinitBaseWorkChain

--- a/aiida_common_workflows/workflows/relax/bigdft/generator.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/generator.py
@@ -57,7 +57,7 @@ def ortho_struct(input_struct):
 
 
 class BigDftRelaxInputGenerator(RelaxInputGenerator):
-    """Input generator for the `BigDFTRelaxWorkChain`."""
+    """Input generator for the `BigDftCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
     _protocols = {

--- a/aiida_common_workflows/workflows/relax/bigdft/generator.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for BigDFT."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for BigDFT."""
 from typing import Any, Dict, List
 
 from aiida import engine
@@ -8,9 +8,9 @@ from aiida import plugins
 from aiida.engine import calcfunction
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('BigDftRelaxInputGenerator',)
+__all__ = ('BigDftCommonRelaxInputGenerator',)
 
 BigDFTParameters = plugins.DataFactory('bigdft')
 StructureData = plugins.DataFactory('structure')
@@ -56,7 +56,7 @@ def ortho_struct(input_struct):
     return out
 
 
-class BigDftRelaxInputGenerator(RelaxInputGenerator):
+class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `BigDftCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'

--- a/aiida_common_workflows/workflows/relax/bigdft/workchain.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/workchain.py
@@ -5,10 +5,10 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import BigDftRelaxInputGenerator
 
-__all__ = ('BigDftRelaxWorkChain',)
+__all__ = ('BigDftCommonRelaxWorkChain',)
 
 
-class BigDftRelaxWorkChain(CommonRelaxWorkChain):
+class BigDftCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for BigDFT."""
 
     _process_class = WorkflowFactory('bigdft.relax')

--- a/aiida_common_workflows/workflows/relax/bigdft/workchain.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/workchain.py
@@ -3,7 +3,7 @@
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import BigDftRelaxInputGenerator
+from .generator import BigDftCommonRelaxInputGenerator
 
 __all__ = ('BigDftCommonRelaxWorkChain',)
 
@@ -12,7 +12,7 @@ class BigDftCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for BigDFT."""
 
     _process_class = WorkflowFactory('bigdft.relax')
-    _generator_class = BigDftRelaxInputGenerator
+    _generator_class = BigDftCommonRelaxInputGenerator
 
     @classmethod
     def define(cls, spec):

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for CASTEP"""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for CASTEP"""
 import collections
 import copy
 import pathlib
@@ -15,15 +15,15 @@ from aiida_castep.data import get_pseudos_from_structure
 from aiida_castep.data.otfg import OTFGGroup
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 # pylint: disable=import-outside-toplevel, too-many-branches, too-many-statements
 
-__all__ = ('CastepRelaxInputGenerator',)
+__all__ = ('CastepCommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')  # pylint: disable=invalid-name
 
 
-class CastepRelaxInputGenerator(RelaxInputGenerator):
+class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `CastepCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
@@ -294,12 +294,12 @@ def generate_inputs(
         family_name = family_name.value
     try:
         otfg_family = OTFGGroup.objects.get(label=family_name)
-    except exceptions.NotExistent:
+    except exceptions.NotExistent as exc:
         raise ValueError(
             'protocol `{}` requires the `{}` `pseudos family` but could not be found.'.format(
                 protocol['name'], protocol['relax']['base']['pseudos_family']
             )
-        )
+        ) from exc
 
     CastepCalculation = plugins.CalculationFactory('castep.castep')  # pylint: disable=invalid-name
     CastepBaseWorkChain = plugins.WorkflowFactory('castep.base')  # pylint: disable=invalid-name
@@ -311,7 +311,7 @@ def generate_inputs(
         try:
             code = orm.load_code(code)
         except (exceptions.MultipleObjectsError, exceptions.NotExistent) as exception:
-            raise ValueError('could not load the code {}: {}'.format(code, exception))
+            raise ValueError('could not load the code {}: {}'.format(code, exception)) from exception
 
     if process_class == CastepCalculation:
         protocol = protocol['relax']['base']['calc']

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -24,7 +24,7 @@ StructureData = plugins.DataFactory('structure')  # pylint: disable=invalid-name
 
 
 class CastepRelaxInputGenerator(RelaxInputGenerator):
-    """Input generator for the `CastepRelaxWorkChain`."""
+    """Input generator for the `CastepCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
     _engine_types = {'relax': {'code_plugin': 'castep.castep', 'description': 'The code to perform the relaxation.'}}
@@ -335,7 +335,7 @@ def generate_inputs_relax(
     otfg_family: OTFGGroup,
     override: Dict[str, Any] = None
 ) -> Dict[str, Any]:
-    """Generate the inputs for the `CastepRelaxWorkChain` for a given code, structure and pseudo potential family.
+    """Generate the inputs for the `CastepCommonRelaxWorkChain` for a given code, structure and pseudo potential family.
 
     :param protocol: the dictionary with protocol inputs.
     :param code: the code to use.

--- a/aiida_common_workflows/workflows/relax/castep/workchain.py
+++ b/aiida_common_workflows/workflows/relax/castep/workchain.py
@@ -7,7 +7,7 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import CastepRelaxInputGenerator
 
-__all__ = ('CastepRelaxWorkChain',)
+__all__ = ('CastepCommonRelaxWorkChain',)
 
 
 @calcfunction
@@ -65,7 +65,7 @@ def get_total_magnetization(parameters):
     return orm.Float(parameters.get_attribute('spin_density'))
 
 
-class CastepRelaxWorkChain(CommonRelaxWorkChain):
+class CastepCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for CASTEP"""
 
     _process_class = WorkflowFactory('castep.relax')

--- a/aiida_common_workflows/workflows/relax/castep/workchain.py
+++ b/aiida_common_workflows/workflows/relax/castep/workchain.py
@@ -5,7 +5,7 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import CastepRelaxInputGenerator
+from .generator import CastepCommonRelaxInputGenerator
 
 __all__ = ('CastepCommonRelaxWorkChain',)
 
@@ -69,7 +69,7 @@ class CastepCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for CASTEP"""
 
     _process_class = WorkflowFactory('castep.relax')
-    _generator_class = CastepRelaxInputGenerator
+    _generator_class = CastepCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for CP2K."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for CP2K."""
 import collections
 import pathlib
 from typing import Any, Dict, List
@@ -11,9 +11,9 @@ from aiida import orm
 from aiida import plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('Cp2kRelaxInputGenerator',)
+__all__ = ('Cp2kCommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')  # pylint: disable=invalid-name
 KpointsData = plugins.DataFactory('array.kpoints')  # pylint: disable=invalid-name
@@ -130,7 +130,7 @@ def get_file_section():
     }
 
 
-class Cp2kRelaxInputGenerator(RelaxInputGenerator):
+class Cp2kCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `Cp2kRelaxWorkChain`."""
 
     _default_protocol = 'moderate'

--- a/aiida_common_workflows/workflows/relax/cp2k/workchain.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/workchain.py
@@ -7,7 +7,7 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import Cp2kRelaxInputGenerator
+from .generator import Cp2kCommonRelaxInputGenerator
 
 __all__ = ('Cp2kCommonRelaxWorkChain',)
 
@@ -68,7 +68,7 @@ class Cp2kCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for CP2K."""
 
     _process_class = Cp2kBaseWorkChain
-    _generator_class = Cp2kRelaxInputGenerator
+    _generator_class = Cp2kCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/cp2k/workchain.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/workchain.py
@@ -9,7 +9,7 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import Cp2kRelaxInputGenerator
 
-__all__ = ('Cp2kRelaxWorkChain',)
+__all__ = ('Cp2kCommonRelaxWorkChain',)
 
 Cp2kBaseWorkChain = WorkflowFactory('cp2k.base')  # pylint: disable=invalid-name
 
@@ -64,7 +64,7 @@ def get_stress_output_folder(folder):
     return stress
 
 
-class Cp2kRelaxWorkChain(CommonRelaxWorkChain):
+class Cp2kCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for CP2K."""
 
     _process_class = Cp2kBaseWorkChain

--- a/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -19,7 +19,7 @@ StructureData = plugins.DataFactory('structure')
 
 
 class FleurRelaxInputGenerator(RelaxInputGenerator):
-    """Generator of inputs for the `FleurRelaxWorkChain`."""
+    """Generator of inputs for the `FleurCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
     _protocols = {

--- a/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for FLEUR."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for FLEUR."""
 import collections
 import pathlib
 from typing import Any, Dict, List
@@ -11,14 +11,14 @@ from aiida import plugins
 from aiida.common.constants import elements as PeriodicTableElements
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('FleurRelaxInputGenerator',)
+__all__ = ('FleurCommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')
 
 
-class FleurRelaxInputGenerator(RelaxInputGenerator):
+class FleurCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Generator of inputs for the `FleurCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'

--- a/aiida_common_workflows/workflows/relax/fleur/workchain.py
+++ b/aiida_common_workflows/workflows/relax/fleur/workchain.py
@@ -5,7 +5,7 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import FleurRelaxInputGenerator
+from .generator import FleurCommonRelaxInputGenerator
 
 __all__ = ('FleurCommonRelaxWorkChain',)
 
@@ -37,7 +37,7 @@ class FleurCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for FLEUR."""
 
     _process_class = WorkflowFactory('fleur.base_relax')
-    _generator_class = FleurRelaxInputGenerator
+    _generator_class = FleurCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/fleur/workchain.py
+++ b/aiida_common_workflows/workflows/relax/fleur/workchain.py
@@ -7,7 +7,7 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import FleurRelaxInputGenerator
 
-__all__ = ('FleurRelaxWorkChain',)
+__all__ = ('FleurCommonRelaxWorkChain',)
 
 
 @calcfunction
@@ -33,7 +33,7 @@ def get_total_magnetization(parameters):
     return orm.Float(parameters.get_attribute('total_magnetic_moment_cell'))
 
 
-class FleurRelaxWorkChain(CommonRelaxWorkChain):
+class FleurCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for FLEUR."""
 
     _process_class = WorkflowFactory('fleur.base_relax')

--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -23,7 +23,7 @@ ANG_TO_BOHR = 1.88972687
 
 
 class GaussianRelaxInputGenerator(RelaxInputGenerator):
-    """Input generator for the `GaussianRelaxWorkChain`."""
+    """Input generator for the `GaussianCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
     _protocols = {

--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for Gaussian."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Gaussian."""
 import copy
 from typing import Any, Dict, List
 
@@ -12,9 +12,9 @@ from aiida import plugins
 from aiida.orm import load_code
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('GaussianRelaxInputGenerator',)
+__all__ = ('GaussianCommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')
 
@@ -22,7 +22,7 @@ EV_TO_EH = 0.03674930814
 ANG_TO_BOHR = 1.88972687
 
 
-class GaussianRelaxInputGenerator(RelaxInputGenerator):
+class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `GaussianCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'

--- a/aiida_common_workflows/workflows/relax/gaussian/workchain.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/workchain.py
@@ -8,7 +8,7 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import GaussianRelaxInputGenerator
 
-__all__ = ('GaussianRelaxWorkChain',)
+__all__ = ('GaussianCommonRelaxWorkChain',)
 
 GaussianBaseWorkChain = WorkflowFactory('gaussian.base')
 
@@ -42,7 +42,7 @@ def get_total_magnetization(parameters):
     return orm.Float(tot_magnetization)
 
 
-class GaussianRelaxWorkChain(CommonRelaxWorkChain):
+class GaussianCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Gaussian."""
 
     _process_class = GaussianBaseWorkChain

--- a/aiida_common_workflows/workflows/relax/gaussian/workchain.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/workchain.py
@@ -6,7 +6,7 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import GaussianRelaxInputGenerator
+from .generator import GaussianCommonRelaxInputGenerator
 
 __all__ = ('GaussianCommonRelaxWorkChain',)
 
@@ -46,7 +46,7 @@ class GaussianCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Gaussian."""
 
     _process_class = GaussianBaseWorkChain
-    _generator_class = GaussianRelaxInputGenerator
+    _generator_class = GaussianCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -8,12 +8,12 @@ from aiida import plugins
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.protocol import ProtocolRegistry
 
-__all__ = ('RelaxInputGenerator',)
+__all__ = ('CommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')
 
 
-class RelaxInputGenerator(ProtocolRegistry, metaclass=ABCMeta):
+class CommonRelaxInputGenerator(ProtocolRegistry, metaclass=ABCMeta):
     """Input generator for the common structure relax workchains.
 
     Subclasses should define the `_engine_types`, `_spin_types`, `_electronic_types` and `_relax_types` class attributes
@@ -103,8 +103,8 @@ class RelaxInputGenerator(ProtocolRegistry, metaclass=ABCMeta):
                 prev_wc_class = reference_workchain.process_class
                 if prev_wc_class not in [self.process_class, self.process_class._process_class]:  # pylint: disable=protected-access
                     raise ValueError('The "reference_workchain" must be a node of {}'.format(self.process_class))
-            except AttributeError:
-                raise ValueError('The "reference_workchain" must be a node of {}'.format(self.process_class))
+            except AttributeError as exc:
+                raise ValueError('The "reference_workchain" must be a node of {}'.format(self.process_class)) from exc
 
         if relax_type not in self._relax_types:
             raise ValueError('relax type `{}` is not supported'.format(relax_type))
@@ -129,8 +129,8 @@ class RelaxInputGenerator(ProtocolRegistry, metaclass=ABCMeta):
         """Return the schema of a particular calculation type for this input generator."""
         try:
             return self._engine_types[key]
-        except KeyError:
-            raise ValueError('the calculation type `{}` does not exist'.format(key))
+        except KeyError as exc:
+            raise ValueError('the calculation type `{}` does not exist'.format(key)) from exc
 
     def get_relax_types(self):
         """Return the available relax types for this input generator."""

--- a/aiida_common_workflows/workflows/relax/nwchem/generator.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for NWChem."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for NWChem."""
 from typing import Any, Dict, List
 import pathlib
 import warnings
@@ -12,16 +12,16 @@ from aiida import orm
 from aiida import plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('NwchemRelaxInputGenerator',)
+__all__ = ('NwchemCommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')
 
 HA_BOHR_TO_EV_A = 51.42208619083232
 
 
-class NwchemRelaxInputGenerator(RelaxInputGenerator):
+class NwchemCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `NwchemCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'

--- a/aiida_common_workflows/workflows/relax/nwchem/generator.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/generator.py
@@ -22,7 +22,7 @@ HA_BOHR_TO_EV_A = 51.42208619083232
 
 
 class NwchemRelaxInputGenerator(RelaxInputGenerator):
-    """Input generator for the `NwchemRelaxWorkChain`."""
+    """Input generator for the `NwchemCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
 

--- a/aiida_common_workflows/workflows/relax/nwchem/workchain.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/workchain.py
@@ -7,7 +7,7 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import NwchemRelaxInputGenerator
+from .generator import NwchemCommonRelaxInputGenerator
 
 __all__ = ('NwchemCommonRelaxWorkChain',)
 
@@ -42,7 +42,7 @@ class NwchemCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for NWChem."""
 
     _process_class = NwchemBaseWorkChain
-    _generator_class = NwchemRelaxInputGenerator
+    _generator_class = NwchemCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/nwchem/workchain.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/workchain.py
@@ -9,7 +9,7 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import NwchemRelaxInputGenerator
 
-__all__ = ('NwchemRelaxWorkChain',)
+__all__ = ('NwchemCommonRelaxWorkChain',)
 
 NwchemBaseWorkChain = WorkflowFactory('nwchem.base')
 
@@ -38,7 +38,7 @@ def get_forces(parameters):
     return forces_ev
 
 
-class NwchemRelaxWorkChain(CommonRelaxWorkChain):
+class NwchemCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for NWChem."""
 
     _process_class = NwchemBaseWorkChain

--- a/aiida_common_workflows/workflows/relax/orca/generator.py
+++ b/aiida_common_workflows/workflows/relax/orca/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for Orca."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Orca."""
 import os
 from typing import Any, Dict, List
 from copy import deepcopy
@@ -13,14 +13,14 @@ from aiida import orm
 from aiida.plugins import DataFactory
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('OrcaRelaxInputGenerator',)
+__all__ = ('OrcaCommonRelaxInputGenerator',)
 
 StructureData = DataFactory('structure')
 
 
-class OrcaRelaxInputGenerator(RelaxInputGenerator):
+class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `OrcaCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'

--- a/aiida_common_workflows/workflows/relax/orca/generator.py
+++ b/aiida_common_workflows/workflows/relax/orca/generator.py
@@ -21,7 +21,7 @@ StructureData = DataFactory('structure')
 
 
 class OrcaRelaxInputGenerator(RelaxInputGenerator):
-    """Input generator for the `OrcaRelaxWorkChain`."""
+    """Input generator for the `OrcaCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
 

--- a/aiida_common_workflows/workflows/relax/orca/workchain.py
+++ b/aiida_common_workflows/workflows/relax/orca/workchain.py
@@ -8,7 +8,7 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import OrcaRelaxInputGenerator
 
-__all__ = ('OrcaRelaxWorkChain',)
+__all__ = ('OrcaCommonRelaxWorkChain',)
 
 OrcaBaseWorkChain = WorkflowFactory('orca.base')
 
@@ -42,7 +42,7 @@ def get_total_magnetization(parameters):
     return Float(tot_magnetization)
 
 
-class OrcaRelaxWorkChain(CommonRelaxWorkChain):
+class OrcaCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Orca."""
 
     _process_class = OrcaBaseWorkChain

--- a/aiida_common_workflows/workflows/relax/orca/workchain.py
+++ b/aiida_common_workflows/workflows/relax/orca/workchain.py
@@ -6,7 +6,7 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import OrcaRelaxInputGenerator
+from .generator import OrcaCommonRelaxInputGenerator
 
 __all__ = ('OrcaCommonRelaxWorkChain',)
 
@@ -46,7 +46,7 @@ class OrcaCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Orca."""
 
     _process_class = OrcaBaseWorkChain
-    _generator_class = OrcaRelaxInputGenerator
+    _generator_class = OrcaCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -15,7 +15,7 @@ StructureData = plugins.DataFactory('structure')
 
 
 class QuantumEspressoRelaxInputGenerator(RelaxInputGenerator):
-    """Input generator for the `QuantumEspressoRelaxWorkChain`."""
+    """Input generator for the `QuantumEspressoCommonRelaxWorkChain`."""
 
     _engine_types = {
         'relax': {
@@ -162,7 +162,7 @@ class QuantumEspressoRelaxInputGenerator(RelaxInputGenerator):
             builder.base_final_scf['kpoints'] = kpoints
 
         # Currently the builder is set for the `PwRelaxWorkChain`, but we should return one for the wrapper workchain
-        # `QuantumEspressoRelaxWorkChain` for which this input generator is built
+        # `QuantumEspressoCommonRelaxWorkChain` for which this input generator is built
         builder._process_class = self.process_class  # pylint: disable=protected-access
 
         return builder

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for Quantum ESPRESSO."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Quantum ESPRESSO."""
 from typing import Any, Dict, List
 
 from aiida import engine
@@ -7,14 +7,14 @@ from aiida import orm
 from aiida import plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('QuantumEspressoRelaxInputGenerator',)
+__all__ = ('QuantumEspressoCommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')
 
 
-class QuantumEspressoRelaxInputGenerator(RelaxInputGenerator):
+class QuantumEspressoCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `QuantumEspressoCommonRelaxWorkChain`."""
 
     _engine_types = {

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/workchain.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/workchain.py
@@ -5,7 +5,7 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import QuantumEspressoRelaxInputGenerator
+from .generator import QuantumEspressoCommonRelaxInputGenerator
 
 __all__ = ('QuantumEspressoCommonRelaxWorkChain',)
 
@@ -40,7 +40,7 @@ class QuantumEspressoCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Quantum ESPRESSO."""
 
     _process_class = WorkflowFactory('quantumespresso.pw.relax')
-    _generator_class = QuantumEspressoRelaxInputGenerator
+    _generator_class = QuantumEspressoCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/workchain.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/workchain.py
@@ -7,7 +7,7 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import QuantumEspressoRelaxInputGenerator
 
-__all__ = ('QuantumEspressoRelaxWorkChain',)
+__all__ = ('QuantumEspressoCommonRelaxWorkChain',)
 
 
 @calcfunction
@@ -36,7 +36,7 @@ def extract_from_parameters(parameters):
     return results
 
 
-class QuantumEspressoRelaxWorkChain(CommonRelaxWorkChain):
+class QuantumEspressoCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Quantum ESPRESSO."""
 
     _process_class = WorkflowFactory('quantumespresso.pw.relax')

--- a/aiida_common_workflows/workflows/relax/siesta/generator.py
+++ b/aiida_common_workflows/workflows/relax/siesta/generator.py
@@ -19,7 +19,7 @@ StructureData = plugins.DataFactory('structure')
 
 
 class SiestaRelaxInputGenerator(RelaxInputGenerator):
-    """Generator of inputs for the SiestaRelaxWorkChain"""
+    """Generator of inputs for the SiestaCommonRelaxWorkChain"""
 
     _default_protocol = 'moderate'
 

--- a/aiida_common_workflows/workflows/relax/siesta/workchain.py
+++ b/aiida_common_workflows/workflows/relax/siesta/workchain.py
@@ -5,7 +5,7 @@ from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import SiestaRelaxInputGenerator
+from .generator import SiestaCommonRelaxInputGenerator
 
 __all__ = ('SiestaCommonRelaxWorkChain',)
 
@@ -36,7 +36,7 @@ class SiestaCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for SIESTA."""
 
     _process_class = WorkflowFactory('siesta.base')
-    _generator_class = SiestaRelaxInputGenerator
+    _generator_class = SiestaCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/siesta/workchain.py
+++ b/aiida_common_workflows/workflows/relax/siesta/workchain.py
@@ -7,7 +7,7 @@ from aiida.plugins import WorkflowFactory
 from ..workchain import CommonRelaxWorkChain
 from .generator import SiestaRelaxInputGenerator
 
-__all__ = ('SiestaRelaxWorkChain',)
+__all__ = ('SiestaCommonRelaxWorkChain',)
 
 
 @calcfunction
@@ -32,7 +32,7 @@ def get_forces_and_stress(totalarray):
     return {'forces': forces, 'stress': stress}
 
 
-class SiestaRelaxWorkChain(CommonRelaxWorkChain):
+class SiestaCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for SIESTA."""
 
     _process_class = WorkflowFactory('siesta.base')

--- a/aiida_common_workflows/workflows/relax/vasp/generator.py
+++ b/aiida_common_workflows/workflows/relax/vasp/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implementation of `aiida_common_workflows.common.relax.generator.RelaxInputGenerator` for VASP."""
+"""Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for VASP."""
 import pathlib
 from typing import Any, Dict, List
 
@@ -11,14 +11,14 @@ from aiida import plugins
 from aiida.common.extendeddicts import AttributeDict
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
-from ..generator import RelaxInputGenerator
+from ..generator import CommonRelaxInputGenerator
 
-__all__ = ('VaspRelaxInputGenerator',)
+__all__ = ('VaspCommonRelaxInputGenerator',)
 
 StructureData = plugins.DataFactory('structure')
 
 
-class VaspRelaxInputGenerator(RelaxInputGenerator):
+class VaspCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `VaspCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'

--- a/aiida_common_workflows/workflows/relax/vasp/generator.py
+++ b/aiida_common_workflows/workflows/relax/vasp/generator.py
@@ -19,7 +19,7 @@ StructureData = plugins.DataFactory('structure')
 
 
 class VaspRelaxInputGenerator(RelaxInputGenerator):
-    """Input generator for the `VASPRelaxWorkChain`."""
+    """Input generator for the `VaspCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
     _engine_types = {'relax': {'code_plugin': 'vasp.vasp', 'description': 'The code to perform the relaxation.'}}

--- a/aiida_common_workflows/workflows/relax/vasp/workchain.py
+++ b/aiida_common_workflows/workflows/relax/vasp/workchain.py
@@ -8,7 +8,7 @@ from aiida.common.exceptions import NotExistentAttributeError
 from ..workchain import CommonRelaxWorkChain
 from .generator import VaspRelaxInputGenerator
 
-__all__ = ('VaspRelaxWorkChain',)
+__all__ = ('VaspCommonRelaxWorkChain',)
 
 
 @calcfunction
@@ -53,7 +53,7 @@ def get_total_cell_magnetic_moment(misc):
     return orm.Float(magnetization)
 
 
-class VaspRelaxWorkChain(CommonRelaxWorkChain):
+class VaspCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for VASP."""
 
     _process_class = WorkflowFactory('vasp.relax')

--- a/aiida_common_workflows/workflows/relax/vasp/workchain.py
+++ b/aiida_common_workflows/workflows/relax/vasp/workchain.py
@@ -6,7 +6,7 @@ from aiida.plugins import WorkflowFactory
 from aiida.common.exceptions import NotExistentAttributeError
 
 from ..workchain import CommonRelaxWorkChain
-from .generator import VaspRelaxInputGenerator
+from .generator import VaspCommonRelaxInputGenerator
 
 __all__ = ('VaspCommonRelaxWorkChain',)
 
@@ -57,7 +57,7 @@ class VaspCommonRelaxWorkChain(CommonRelaxWorkChain):
     """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for VASP."""
 
     _process_class = WorkflowFactory('vasp.relax')
-    _generator_class = VaspRelaxInputGenerator
+    _generator_class = VaspCommonRelaxInputGenerator
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""

--- a/aiida_common_workflows/workflows/relax/workchain.py
+++ b/aiida_common_workflows/workflows/relax/workchain.py
@@ -5,7 +5,7 @@ from abc import ABCMeta, abstractmethod
 from aiida.engine import WorkChain, ToContext
 from aiida.orm import StructureData, ArrayData, TrajectoryData, Float
 
-from .generator import RelaxInputGenerator
+from .generator import CommonRelaxInputGenerator
 
 __all__ = ('CommonRelaxWorkChain',)
 
@@ -22,7 +22,7 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
     _generator_class = None
 
     @classmethod
-    def get_input_generator(cls) -> RelaxInputGenerator:
+    def get_input_generator(cls) -> CommonRelaxInputGenerator:
         """Return an instance of the input generator for this work chain.
 
         :return: input generator

--- a/setup.json
+++ b/setup.json
@@ -58,16 +58,16 @@
         "aiida.workflows": [
             "common_workflows.eos = aiida_common_workflows.workflows.eos:EquationOfStateWorkChain",
             "common_workflows.dissociation_curve = aiida_common_workflows.workflows.dissociation:DissociationCurveWorkChain",
-            "common_workflows.relax.abinit = aiida_common_workflows.workflows.relax.abinit.workchain:AbinitRelaxWorkChain",
-            "common_workflows.relax.bigdft = aiida_common_workflows.workflows.relax.bigdft.workchain:BigDftRelaxWorkChain",
-            "common_workflows.relax.castep = aiida_common_workflows.workflows.relax.castep.workchain:CastepRelaxWorkChain",
-            "common_workflows.relax.cp2k = aiida_common_workflows.workflows.relax.cp2k.workchain:Cp2kRelaxWorkChain",
-            "common_workflows.relax.fleur = aiida_common_workflows.workflows.relax.fleur.workchain:FleurRelaxWorkChain",
-            "common_workflows.relax.gaussian = aiida_common_workflows.workflows.relax.gaussian.workchain:GaussianRelaxWorkChain",
-            "common_workflows.relax.orca = aiida_common_workflows.workflows.relax.orca.workchain:OrcaRelaxWorkChain",
-            "common_workflows.relax.quantum_espresso = aiida_common_workflows.workflows.relax.quantum_espresso.workchain:QuantumEspressoRelaxWorkChain",
-            "common_workflows.relax.siesta = aiida_common_workflows.workflows.relax.siesta.workchain:SiestaRelaxWorkChain",
-            "common_workflows.relax.vasp = aiida_common_workflows.workflows.relax.vasp.workchain:VaspRelaxWorkChain"
+            "common_workflows.relax.abinit = aiida_common_workflows.workflows.relax.abinit.workchain:AbinitCommonRelaxWorkChain",
+            "common_workflows.relax.bigdft = aiida_common_workflows.workflows.relax.bigdft.workchain:BigDftCommonRelaxWorkChain",
+            "common_workflows.relax.castep = aiida_common_workflows.workflows.relax.castep.workchain:CastepCommonRelaxWorkChain",
+            "common_workflows.relax.cp2k = aiida_common_workflows.workflows.relax.cp2k.workchain:Cp2kCommonRelaxWorkChain",
+            "common_workflows.relax.fleur = aiida_common_workflows.workflows.relax.fleur.workchain:FleurCommonRelaxWorkChain",
+            "common_workflows.relax.gaussian = aiida_common_workflows.workflows.relax.gaussian.workchain:GaussianCommonRelaxWorkChain",
+            "common_workflows.relax.orca = aiida_common_workflows.workflows.relax.orca.workchain:OrcaCommonRelaxWorkChain",
+            "common_workflows.relax.quantum_espresso = aiida_common_workflows.workflows.relax.quantum_espresso.workchain:QuantumEspressoCommonRelaxWorkChain",
+            "common_workflows.relax.siesta = aiida_common_workflows.workflows.relax.siesta.workchain:SiestaCommonRelaxWorkChain",
+            "common_workflows.relax.vasp = aiida_common_workflows.workflows.relax.vasp.workchain:VaspCommonRelaxWorkChain"
         ]
     },
     "license": "MIT License",

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -113,7 +113,7 @@ def test_eos_number_mpi_procs_per_machine(run_cli_command, generate_structure, g
     options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
     assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '\
-           'steps, so requires 1 values' in result.output_line
+           'steps, so requires 1 values' in result.output_lines
 
 
 @pytest.mark.usefixtures('aiida_profile')

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -16,7 +16,7 @@ def test_relax_wallclock_seconds(run_cli_command, generate_structure, generate_c
     # Passing two values for `-w` should raise as only one value is required
     options = ['-S', str(structure.pk), '-w', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_relax, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
 
 
@@ -29,7 +29,7 @@ def test_relax_number_machines(run_cli_command, generate_structure, generate_cod
     # Passing two values for `-m` should raise as only one value is required
     options = ['-S', str(structure.pk), '-m', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_relax, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-machines: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+    assert 'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
 
 
@@ -44,7 +44,7 @@ def test_relax_number_mpi_procs_per_machine(run_cli_command, generate_structure,
     # Passing two values for `-n` should raise as only one value is required
     options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_relax, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoRelaxWorkChain has 1 engine ' \
+    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '\
            'steps, so requires 1 values' in result.output_lines
 
 
@@ -84,7 +84,7 @@ def test_eos_wallclock_seconds(run_cli_command, generate_structure, generate_cod
     # Passing two values for `-w` should raise as only one value is required
     options = ['-S', str(structure.pk), '-w', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
 
 
@@ -97,7 +97,7 @@ def test_eos_number_machines(run_cli_command, generate_structure, generate_code)
     # Passing two values for `-m` should raise as only one value is required
     options = ['-S', str(structure.pk), '-m', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-machines: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+    assert 'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
 
 
@@ -112,8 +112,8 @@ def test_eos_number_mpi_procs_per_machine(run_cli_command, generate_structure, g
     # Passing two values for `-n` should raise as only one value is required
     options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoRelaxWorkChain has 1 engine ' \
-           'steps, so requires 1 values' in result.output_lines
+    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '\
+           'steps, so requires 1 values' in result.output_line
 
 
 @pytest.mark.usefixtures('aiida_profile')
@@ -182,7 +182,7 @@ def test_dissociation_curve_wallclock_seconds(run_cli_command, generate_structur
     # Passing two values for `-w` should raise as only one value is required
     options = ['-S', str(structure.pk), '-w', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_dissociation_curve, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
 
 
@@ -195,7 +195,7 @@ def test_dissociation_curve_number_machines(run_cli_command, generate_structure,
     # Passing two values for `-m` should raise as only one value is required
     options = ['-S', str(structure.pk), '-m', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_dissociation_curve, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-machines: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+    assert 'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
 
 
@@ -210,7 +210,7 @@ def test_dissociation_curve_number_mpi_procs_per_machine(run_cli_command, genera
     # Passing two values for `-n` should raise as only one value is required
     options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_dissociation_curve, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoRelaxWorkChain has 1 engine ' \
+    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '\
            'steps, so requires 1 values' in result.output_lines
 
 

--- a/tests/workflows/relax/test_castep.py
+++ b/tests/workflows/relax/test_castep.py
@@ -12,7 +12,7 @@ from aiida_castep.data.otfg import OTFGGroup
 
 from aiida_common_workflows.workflows.relax.castep.workchain import CastepCommonRelaxWorkChain
 from aiida_common_workflows.workflows.relax.castep.generator import (
-    CastepRelaxInputGenerator, generate_inputs, generate_inputs_base, generate_inputs_calculation,
+    CastepCommonRelaxInputGenerator, generate_inputs, generate_inputs_base, generate_inputs_calculation,
     generate_inputs_relax, ensure_otfg_family, RelaxType, ElectronicType, SpinType
 )
 
@@ -93,7 +93,8 @@ def test_base_generator(castep_code, nacl, with_otfg):
 def test_relax_generator(castep_code, nacl, with_otfg):
     """Test for generating the relax namespace"""
     CastepCommonRelaxWorkChain = WorkflowFactory('castep.relax')  # pylint: disable=invalid-name
-    protocol = CastepRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain).get_protocol('moderate')['relax']
+    protocol = CastepCommonRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain
+                                               ).get_protocol('moderate')['relax']
     override = {
         'base': {
             'metadata': {
@@ -126,7 +127,7 @@ def test_generate_inputs(castep_code, nacl, si):  # pylint: disable=invalid-name
     """
     Test for the generator
     """
-    protocol = CastepRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain).get_protocol('moderate')
+    protocol = CastepCommonRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain).get_protocol('moderate')
     override = {'base': {'metadata': {'label': 'test'}, 'calc': {}}}
 
     output = generate_inputs(WorkflowFactory('castep.relax'), copy.deepcopy(protocol), castep_code, si, override)
@@ -140,7 +141,7 @@ def test_generate_inputs(castep_code, nacl, si):  # pylint: disable=invalid-name
 
 def test_input_generator(castep_code, nacl, si):  # pylint: disable=invalid-name
     """Test for the input generator"""
-    gen = CastepRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain)
+    gen = CastepCommonRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain)
     engines = {'relax': {'code': castep_code, 'options': {}}}
     builder = gen.get_builder(si, engines, protocol='moderate')
     param = builder.calc.parameters.get_dict()

--- a/tests/workflows/relax/test_castep.py
+++ b/tests/workflows/relax/test_castep.py
@@ -10,7 +10,7 @@ from aiida.plugins import WorkflowFactory
 from ase.build.bulk import bulk
 from aiida_castep.data.otfg import OTFGGroup
 
-from aiida_common_workflows.workflows.relax.castep.workchain import CastepRelaxWorkChain
+from aiida_common_workflows.workflows.relax.castep.workchain import CastepCommonRelaxWorkChain
 from aiida_common_workflows.workflows.relax.castep.generator import (
     CastepRelaxInputGenerator, generate_inputs, generate_inputs_base, generate_inputs_calculation,
     generate_inputs_relax, ensure_otfg_family, RelaxType, ElectronicType, SpinType
@@ -92,8 +92,8 @@ def test_base_generator(castep_code, nacl, with_otfg):
 
 def test_relax_generator(castep_code, nacl, with_otfg):
     """Test for generating the relax namespace"""
-    CastepRelaxWorkChain = WorkflowFactory('castep.relax')  # pylint: disable=invalid-name
-    protocol = CastepRelaxInputGenerator(process_class=CastepRelaxWorkChain).get_protocol('moderate')['relax']
+    CastepCommonRelaxWorkChain = WorkflowFactory('castep.relax')  # pylint: disable=invalid-name
+    protocol = CastepRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain).get_protocol('moderate')['relax']
     override = {
         'base': {
             'metadata': {
@@ -126,7 +126,7 @@ def test_generate_inputs(castep_code, nacl, si):  # pylint: disable=invalid-name
     """
     Test for the generator
     """
-    protocol = CastepRelaxInputGenerator(process_class=CastepRelaxWorkChain).get_protocol('moderate')
+    protocol = CastepRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain).get_protocol('moderate')
     override = {'base': {'metadata': {'label': 'test'}, 'calc': {}}}
 
     output = generate_inputs(WorkflowFactory('castep.relax'), copy.deepcopy(protocol), castep_code, si, override)
@@ -140,7 +140,7 @@ def test_generate_inputs(castep_code, nacl, si):  # pylint: disable=invalid-name
 
 def test_input_generator(castep_code, nacl, si):  # pylint: disable=invalid-name
     """Test for the input generator"""
-    gen = CastepRelaxInputGenerator(process_class=CastepRelaxWorkChain)
+    gen = CastepRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain)
     engines = {'relax': {'code': castep_code, 'options': {}}}
     builder = gen.get_builder(si, engines, protocol='moderate')
     param = builder.calc.parameters.get_dict()

--- a/tests/workflows/relax/test_generator.py
+++ b/tests/workflows/relax/test_generator.py
@@ -5,7 +5,7 @@ import pytest
 
 from aiida_common_workflows.protocol import ProtocolRegistry
 from aiida_common_workflows.common import RelaxType, SpinType, ElectronicType
-from aiida_common_workflows.workflows.relax import RelaxInputGenerator
+from aiida_common_workflows.workflows.relax import CommonRelaxInputGenerator
 from aiida_common_workflows.workflows.relax.workchain import CommonRelaxWorkChain
 
 
@@ -23,10 +23,10 @@ def protocol_registry() -> ProtocolRegistry:
 
 
 @pytest.fixture
-def inputs_generator(protocol_registry) -> RelaxInputGenerator:
+def inputs_generator(protocol_registry) -> CommonRelaxInputGenerator:
     """Return an instance of a relax input generator implementation."""
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Valid input generator implementation."""
 
         _engine_types = {'relax': {'code_plugin': 'entry.point', 'description': 'test'}}
@@ -51,7 +51,7 @@ def test_validation(protocol_registry):
 
     # pylint: disable=abstract-class-instantiated,function-redefined,too-many-statements
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: no ``get_builder``"""
 
         _engine_types = None
@@ -63,7 +63,7 @@ def test_validation(protocol_registry):
     with pytest.raises(TypeError):
         InputGenerator()
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: no process class passed."""
 
         _engine_types = {'relax': {}}
@@ -75,7 +75,7 @@ def test_validation(protocol_registry):
     with pytest.raises(RuntimeError):
         InputGenerator()
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: no ``_relax_types``"""
 
         _engine_types = {'relax': {}}
@@ -89,7 +89,7 @@ def test_validation(protocol_registry):
     with pytest.raises(RuntimeError):
         InputGenerator(process_class=CommonRelaxWorkChain)
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: no ``_engine_types``"""
 
         _engine_types = None
@@ -103,7 +103,7 @@ def test_validation(protocol_registry):
     with pytest.raises(RuntimeError):
         InputGenerator(process_class=CommonRelaxWorkChain)
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: no ``_spin_types``"""
 
         _engine_types = {'relax': {}}
@@ -117,7 +117,7 @@ def test_validation(protocol_registry):
     with pytest.raises(RuntimeError):
         InputGenerator(process_class=CommonRelaxWorkChain)
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: no ``_electronic_types``"""
 
         _engine_types = {'relax': {}}
@@ -131,7 +131,7 @@ def test_validation(protocol_registry):
     with pytest.raises(RuntimeError):
         InputGenerator(process_class=CommonRelaxWorkChain)
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: invalid ``_relax_types``"""
 
         _engine_types = {'relax': {}}
@@ -145,7 +145,7 @@ def test_validation(protocol_registry):
     with pytest.raises(RuntimeError):
         InputGenerator(process_class=CommonRelaxWorkChain)
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: invalid ``_spin_types``"""
 
         _engine_types = {'relax': {}}
@@ -159,7 +159,7 @@ def test_validation(protocol_registry):
     with pytest.raises(RuntimeError):
         InputGenerator(process_class=CommonRelaxWorkChain)
 
-    class InputGenerator(protocol_registry, RelaxInputGenerator):
+    class InputGenerator(protocol_registry, CommonRelaxInputGenerator):
         """Invalid input generator implementation: invalid ``_electronic_types``"""
 
         _engine_types = {'relax': {}}
@@ -175,25 +175,25 @@ def test_validation(protocol_registry):
 
 
 def test_get_engine_types(inputs_generator):
-    """Test `RelaxInputGenerator.get_engine_types`."""
+    """Test `CommonRelaxInputGenerator.get_engine_types`."""
     assert inputs_generator.get_engine_types() == ['relax']
 
 
 def test_get_engine_type_schema(inputs_generator):
-    """Test `RelaxInputGenerator.get_engine_type_schema`."""
+    """Test `CommonRelaxInputGenerator.get_engine_type_schema`."""
     assert inputs_generator.get_engine_type_schema('relax') == {'code_plugin': 'entry.point', 'description': 'test'}
 
 
 def test_get_relax_types(inputs_generator):
-    """Test `RelaxInputGenerator.get_relax_types`."""
+    """Test `CommonRelaxInputGenerator.get_relax_types`."""
     assert set(inputs_generator.get_relax_types()) == {RelaxType.POSITIONS, RelaxType.POSITIONS_CELL}
 
 
 def test_get_spin_types(inputs_generator):
-    """Test `RelaxInputGenerator.get_spin_types`."""
+    """Test `CommonRelaxInputGenerator.get_spin_types`."""
     assert set(inputs_generator.get_spin_types()) == {SpinType.NONE, SpinType.COLLINEAR}
 
 
 def test_get_electronic_types(inputs_generator):
-    """Test `RelaxInputGenerator.get_electronic_types`."""
+    """Test `CommonRelaxInputGenerator.get_electronic_types`."""
     assert set(inputs_generator.get_electronic_types()) == {ElectronicType.INSULATOR, ElectronicType.METAL}

--- a/tests/workflows/relax/test_workchain.py
+++ b/tests/workflows/relax/test_workchain.py
@@ -6,7 +6,7 @@ import pytest
 from aiida.plugins import WorkflowFactory
 
 from aiida_common_workflows.plugins import get_workflow_entry_point_names
-from aiida_common_workflows.workflows.relax import RelaxInputGenerator
+from aiida_common_workflows.workflows.relax import CommonRelaxInputGenerator
 from aiida_common_workflows.workflows.relax.workchain import CommonRelaxWorkChain
 
 
@@ -24,5 +24,5 @@ def test_workchain_class(workchain):
 def test_get_input_generator(workchain):
     """Test that each registered common relax workchain defines the associated input generator."""
     generator = workchain.get_input_generator()
-    assert isinstance(generator, RelaxInputGenerator)
+    assert isinstance(generator, CommonRelaxInputGenerator)
     assert issubclass(generator.process_class, CommonRelaxWorkChain)


### PR DESCRIPTION
Fixes #163 

The common suffix used so far for all implementations of the common
relax workchain was `RelaxWorkChain`. However, given that many plugins
already use this suffix for their own specific relax workflows, it was
difficult to distinguish these workchains from the one with the common
interface from `aiida-common-workflows`. Therefore, we add the term
`common` explicitly into it and make the suffix `CommonRelaxWorkChain`.