### PR TITLE
Add the option `--number-mpi-procs-per-machine` to the cli.

### DIFF
--- a/aiida_common_workflows/cli/launch.py
+++ b/aiida_common_workflows/cli/launch.py
@@ -59,8 +59,7 @@ def cmd_relax(  #pylint: disable=too-many-branches
             param_hint='--number-machines'
         )
 
-    if number_mpi_procs_per_machine is not None:
-        if len(number_mpi_procs_per_machine) != number_engines:
+    if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
             raise click.BadParameter(
                 f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
                 param_hint='--number-mpi-procs-per-machine'
@@ -177,8 +176,7 @@ def cmd_eos(  #pylint: disable=too-many-branches
             param_hint='--number-machines'
         )
 
-    if number_mpi_procs_per_machine is not None:
-        if len(number_mpi_procs_per_machine) != number_engines:
+    if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
             raise click.BadParameter(
                 f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
                 param_hint='--number-mpi-procs-per-machine'
@@ -304,8 +302,7 @@ def cmd_dissociation_curve(  #pylint: disable=too-many-branches
             param_hint='--number-machines'
         )
 
-    if number_mpi_procs_per_machine is not None:
-        if len(number_mpi_procs_per_machine) != number_engines:
+    if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
             raise click.BadParameter(
                 f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
                 param_hint='--number-mpi-procs-per-machine'

--- a/aiida_common_workflows/cli/launch.py
+++ b/aiida_common_workflows/cli/launch.py
@@ -27,14 +27,15 @@ def cmd_launch():
 @options.THRESHOLD_FORCES()
 @options.THRESHOLD_STRESS()
 @options.NUMBER_MACHINES()
+@options.NUMBER_MPI_PROCS_PER_MACHINE()
 @options.WALLCLOCK_SECONDS()
 @options.DAEMON()
 @options.MAGNETIZATION_PER_SITE()
 @options.REFERENCE_WORKCHAIN()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
-def cmd_relax(
+def cmd_relax(  #pylint: disable=too-many-branches
     plugin, structure, codes, protocol, relax_type, spin_type, threshold_forces, threshold_stress, number_machines,
-    wallclock_seconds, daemon, magnetization_per_site, reference_workchain, show_engines
+    number_mpi_procs_per_machine, wallclock_seconds, daemon, magnetization_per_site, reference_workchain, show_engines
 ):
     """Relax a crystal structure using the common relax workflow for one of the existing plugin implementations.
 
@@ -57,6 +58,13 @@ def cmd_relax(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
             param_hint='--number-machines'
         )
+
+    if number_mpi_procs_per_machine is not None:
+        if len(number_mpi_procs_per_machine) != number_engines:
+            raise click.BadParameter(
+                f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
+                param_hint='--number-mpi-procs-per-machine'
+            )
 
     if wallclock_seconds is None:
         wallclock_seconds = [1 * 3600] * number_engines
@@ -100,11 +108,16 @@ def cmd_relax(
             'code': code.full_label,
             'options': {
                 'resources': {
-                    'num_machines': number_machines[index]
+                    'num_machines': number_machines[index],
                 },
                 'max_wallclock_seconds': wallclock_seconds[index],
             }
         }
+
+        if number_mpi_procs_per_machine is not None:
+            engines[engine]['options']['resources']['num_mpiprocs_per_machine'] = number_mpi_procs_per_machine[index]
+            if number_mpi_procs_per_machine[index] > 1:
+                engines[engine]['options']['withmpi'] = True
 
     builder = generator.get_builder(
         structure,
@@ -130,13 +143,14 @@ def cmd_relax(
 @options.THRESHOLD_FORCES()
 @options.THRESHOLD_STRESS()
 @options.NUMBER_MACHINES()
+@options.NUMBER_MPI_PROCS_PER_MACHINE()
 @options.WALLCLOCK_SECONDS()
 @options.DAEMON()
 @options.MAGNETIZATION_PER_SITE()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
-def cmd_eos(
+def cmd_eos(  #pylint: disable=too-many-branches
     plugin, structure, codes, protocol, relax_type, spin_type, threshold_forces, threshold_stress, number_machines,
-    wallclock_seconds, daemon, magnetization_per_site, show_engines
+    number_mpi_procs_per_machine, wallclock_seconds, daemon, magnetization_per_site, show_engines
 ):
     """Compute the equation of state of a crystal structure using the common relax workflow.
 
@@ -163,6 +177,13 @@ def cmd_eos(
             param_hint='--number-machines'
         )
 
+    if number_mpi_procs_per_machine is not None:
+        if len(number_mpi_procs_per_machine) != number_engines:
+            raise click.BadParameter(
+                f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
+                param_hint='--number-mpi-procs-per-machine'
+            )
+
     if wallclock_seconds is None:
         wallclock_seconds = [1 * 3600] * number_engines
 
@@ -209,6 +230,11 @@ def cmd_eos(
                 'max_wallclock_seconds': wallclock_seconds[index],
             }
         }
+
+        if number_mpi_procs_per_machine is not None:
+            engines[engine]['options']['resources']['num_mpiprocs_per_machine'] = number_mpi_procs_per_machine[index]
+            if number_mpi_procs_per_machine[index] > 1:
+                engines[engine]['options']['withmpi'] = True
 
     inputs = {
         'structure': structure,
@@ -240,13 +266,14 @@ def cmd_eos(
 @options.PROTOCOL(type=click.Choice(['fast', 'moderate', 'precise']), default='fast')
 @options.SPIN_TYPE()
 @options.NUMBER_MACHINES()
+@options.NUMBER_MPI_PROCS_PER_MACHINE()
 @options.WALLCLOCK_SECONDS()
 @options.DAEMON()
 @options.MAGNETIZATION_PER_SITE()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
-def cmd_dissociation_curve(
-    plugin, structure, codes, protocol, spin_type, number_machines, wallclock_seconds, daemon, magnetization_per_site,
-    show_engines
+def cmd_dissociation_curve(  #pylint: disable=too-many-branches
+    plugin, structure, codes, protocol, spin_type, number_machines, number_mpi_procs_per_machine, wallclock_seconds,
+    daemon, magnetization_per_site, show_engines
 ):
     """Compute the dissociation curve of a diatomic molecule using the common relax workflow.
 
@@ -276,6 +303,13 @@ def cmd_dissociation_curve(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
             param_hint='--number-machines'
         )
+
+    if number_mpi_procs_per_machine is not None:
+        if len(number_mpi_procs_per_machine) != number_engines:
+            raise click.BadParameter(
+                f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
+                param_hint='--number-mpi-procs-per-machine'
+            )
 
     if wallclock_seconds is None:
         wallclock_seconds = [1 * 3600] * number_engines
@@ -324,6 +358,11 @@ def cmd_dissociation_curve(
                 'max_wallclock_seconds': wallclock_seconds[index],
             }
         }
+
+        if number_mpi_procs_per_machine is not None:
+            engines[engine]['options']['resources']['num_mpiprocs_per_machine'] = number_mpi_procs_per_machine[index]
+            if number_mpi_procs_per_machine[index] > 1:
+                engines[engine]['options']['withmpi'] = True
 
     inputs = {
         'molecule': structure,

--- a/aiida_common_workflows/cli/launch.py
+++ b/aiida_common_workflows/cli/launch.py
@@ -60,10 +60,10 @@ def cmd_relax(  #pylint: disable=too-many-branches
         )
 
     if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
-            raise click.BadParameter(
-                f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-                param_hint='--number-mpi-procs-per-machine'
-            )
+        raise click.BadParameter(
+            f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
+            param_hint='--number-mpi-procs-per-machine'
+        )
 
     if wallclock_seconds is None:
         wallclock_seconds = [1 * 3600] * number_engines
@@ -177,10 +177,10 @@ def cmd_eos(  #pylint: disable=too-many-branches
         )
 
     if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
-            raise click.BadParameter(
-                f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-                param_hint='--number-mpi-procs-per-machine'
-            )
+        raise click.BadParameter(
+            f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
+            param_hint='--number-mpi-procs-per-machine'
+        )
 
     if wallclock_seconds is None:
         wallclock_seconds = [1 * 3600] * number_engines
@@ -303,10 +303,10 @@ def cmd_dissociation_curve(  #pylint: disable=too-many-branches
         )
 
     if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
-            raise click.BadParameter(
-                f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-                param_hint='--number-mpi-procs-per-machine'
-            )
+        raise click.BadParameter(
+            f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
+            param_hint='--number-mpi-procs-per-machine'
+        )
 
     if wallclock_seconds is None:
         wallclock_seconds = [1 * 3600] * number_engines

--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -184,6 +184,16 @@ NUMBER_MACHINES = options.OverridableOption(
     help='Define the number of machines to request for each engine step.'
 )
 
+NUMBER_MPI_PROCS_PER_MACHINE = options.OverridableOption(
+    '-n',
+    '--number-mpi-procs-per-machine',
+    cls=options.MultipleValueOption,
+    type=click.INT,
+    metavar='VALUES',
+    required=False,
+    help='Define the number of mpi processor per machines to request for each engine step.'
+)
+
 MAGNETIZATION_PER_SITE = options.OverridableOption(
     '--magnetization-per-site',
     type=click.FLOAT,

--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -191,7 +191,7 @@ NUMBER_MPI_PROCS_PER_MACHINE = options.OverridableOption(
     type=click.INT,
     metavar='VALUES',
     required=False,
-    help='Define the number of mpi processor per machines to request for each engine step.'
+    help='Define the number of MPI processes per machine to request for each engine step.'
 )
 
 MAGNETIZATION_PER_SITE = options.OverridableOption(

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -44,8 +44,8 @@ def test_relax_number_mpi_procs_per_machine(run_cli_command, generate_structure,
     # Passing two values for `-n` should raise as only one value is required
     options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_relax, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
-           'requires 1 values' in result.output_lines
+    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoRelaxWorkChain has 1 engine ' \
+           'steps, so requires 1 values' in result.output_lines
 
 
 @pytest.mark.usefixtures('clear_database_before_test')
@@ -99,6 +99,21 @@ def test_eos_number_machines(run_cli_command, generate_structure, generate_code)
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
     assert 'Error: Invalid value for --number-machines: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_eos_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
+    """Test the `--number-mpi-procs-per-machine` option."""
+    structure = generate_structure().store()
+    code = generate_code('quantumespresso.pw')
+    code.computer.set_default_mpiprocs_per_machine(2)
+    code.store()
+
+    # Passing two values for `-n` should raise as only one value is required
+    options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
+    result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
+    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoRelaxWorkChain has 1 engine ' \
+           'steps, so requires 1 values' in result.output_lines
 
 
 @pytest.mark.usefixtures('aiida_profile')
@@ -182,6 +197,21 @@ def test_dissociation_curve_number_machines(run_cli_command, generate_structure,
     result = run_cli_command(launch.cmd_dissociation_curve, options, raises=click.BadParameter)
     assert 'Error: Invalid value for --number-machines: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
            'requires 1 values' in result.output_lines
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_dissociation_curve_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
+    """Test the `--number-mpi-procs-per-machine` option."""
+    structure = generate_structure().store()
+    code = generate_code('quantumespresso.pw')
+    code.computer.set_default_mpiprocs_per_machine(2)
+    code.store()
+
+    # Passing two values for `-n` should raise as only one value is required
+    options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
+    result = run_cli_command(launch.cmd_dissociation_curve, options, raises=click.BadParameter)
+    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoRelaxWorkChain has 1 engine ' \
+           'steps, so requires 1 values' in result.output_lines
 
 
 @pytest.mark.usefixtures('aiida_profile')

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -33,6 +33,21 @@ def test_relax_number_machines(run_cli_command, generate_structure, generate_cod
            'requires 1 values' in result.output_lines
 
 
+@pytest.mark.usefixtures('aiida_profile')
+def test_relax_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
+    """Test the `--number-mpi-procs-per-machine` option."""
+    structure = generate_structure().store()
+    code = generate_code('quantumespresso.pw')
+    code.computer.set_default_mpiprocs_per_machine(2)
+    code.store()
+
+    # Passing two values for `-n` should raise as only one value is required
+    options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
+    result = run_cli_command(launch.cmd_relax, options, raises=click.BadParameter)
+    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoRelaxWorkChain has 1 engine steps, so ' \
+           'requires 1 values' in result.output_lines
+
+
 @pytest.mark.usefixtures('clear_database_before_test')
 def test_relax_codes(run_cli_command, generate_structure, generate_code, monkeypatch):
     """Test the `--codes` option."""


### PR DESCRIPTION
Added the option to pass the numper of mpi processor per machine through
cli, its short is `-n`.

As mentioned in #165, implemented that, for each engine, if this quantity is specified
and it is bigger than 1, the `withmpi = True` is also set in the calculation options.

Fixes #165 and fixes #115