### PR TITLE
Dependencies: temporarily limit upper version of `sqlalchemy`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -28,7 +28,8 @@
         "aiida-quantumespresso~=3.4",
         "aiida-siesta~=1.1",
         "aiida-vasp",
-        "ase==3.19"
+        "ase==3.19",
+        "sqlalchemy<1.4"
     ],
     "extras_require": {
         "docs": [


### PR DESCRIPTION
The newly released `sqlalchemy==1.4.0` breaks `sqlalchemy-utils` and so
breaks all the tests. Until the latter releases a fix, we have to put an
upper limit on the `sqlalchemy` dependency.