### PR TITLE
Gaussian protocol update

### DIFF
--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -33,7 +33,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             'basis_set': 'Def2SVP',
             'route_parameters': {
                 'nosymm': None,
-                'opt': None,
+                'opt': 'loose',
             }
         },
         'moderate': {
@@ -43,7 +43,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             'route_parameters': {
                 'int': 'ultrafine',
                 'nosymm': None,
-                'opt': 'tight',
+                'opt': None,
             }
         },
         'precise': {


### PR DESCRIPTION
Hi, this PR makes the optimization thresholds to be more in-line with other codes. After the PR changes, the following table compares the max force convergence criteria for Gaussian, Orca and QE:

protocol | Gaussian | Orca | QE |
--- | --- | --- | --- |
fast | 25e-4 | 20e-4 | 10e-4 |
moderate | 4.5e-4 | 3e-4 | 1e-4 |
precise | 0.15e-4 | 1e-4 | 0.5e-4 |

"precise" is still a bit tighter than the others but it's the next "standard" gaussian-defined threshold (`opt=tight` as opposed to the "normal" `opt` that the moderate protocol uses)