### PR TITLE
`CommonRelaxInputGenerator`: allow str for enum keyword arguments

### DIFF
--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -3,7 +3,7 @@
 import collections
 import copy
 import pathlib
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 import warnings
 
 import yaml
@@ -61,10 +61,10 @@ class AbinitCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -103,6 +103,15 @@ class AbinitCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         protocol = copy.deepcopy(self.get_protocol(protocol))
         code = engines['relax']['code']

--- a/aiida_common_workflows/workflows/relax/bigdft/generator.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/generator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for BigDFT."""
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 
 from aiida import engine
 from aiida import orm
@@ -163,10 +163,10 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -205,6 +205,15 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         builder = self.process_class.get_builder()
 

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -4,7 +4,7 @@ import collections
 import copy
 import pathlib
 from math import pi
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 import yaml
 
 from aiida import engine
@@ -71,10 +71,10 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -113,6 +113,15 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         # Taken from http://greif.geo.berkeley.edu/~driver/conversions.html
         # 1 eV/Angstrom3 = 160.21766208 GPa

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -2,7 +2,7 @@
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for CP2K."""
 import collections
 import pathlib
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 import yaml
 import numpy as np
 
@@ -165,10 +165,10 @@ class Cp2kCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -191,7 +191,7 @@ class Cp2kCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals,too-many-statements,too-many-branches
         protocol = protocol or self.get_default_protocol_name()
 
         super().get_builder(
@@ -207,6 +207,15 @@ class Cp2kCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         # The builder.
         builder = self.process_class.get_builder()

--- a/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -2,7 +2,7 @@
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for FLEUR."""
 import collections
 import pathlib
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 import yaml
 
 from aiida import engine
@@ -76,10 +76,10 @@ class FleurCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -121,6 +121,15 @@ class FleurCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             **kwargs
         )
         # pylint: disable=too-many-locals
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         inpgen_code = engines['inpgen']['code']
         fleur_code = engines['relax']['code']

--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Gaussian."""
 import copy
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 
@@ -75,10 +75,10 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -117,6 +117,15 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         if any(structure.get_attribute_many(['pbc1', 'pbc2', 'pbc3'])):
             print('Warning: PBC detected in input structure. It is not supported and thus ignored.')

--- a/aiida_common_workflows/workflows/relax/nwchem/generator.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/generator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for NWChem."""
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 import pathlib
 import warnings
 import yaml
@@ -58,10 +58,10 @@ class NwchemCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -100,6 +100,15 @@ class NwchemCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         # Protocol
         parameters = self.get_protocol(protocol)

--- a/aiida_common_workflows/workflows/relax/orca/generator.py
+++ b/aiida_common_workflows/workflows/relax/orca/generator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Orca."""
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 from copy import deepcopy
 import warnings
 
@@ -64,10 +64,10 @@ class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -105,6 +105,15 @@ class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         # Checks
         if any(structure.get_attribute_many(['pbc1', 'pbc2', 'pbc2'])):

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Quantum ESPRESSO."""
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 
 from aiida import engine
 from aiida import orm
@@ -106,10 +106,10 @@ class QuantumEspressoCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -132,7 +132,7 @@ class QuantumEspressoCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         :param kwargs: any inputs that are specific to the plugin.
         :return: a `aiida.engine.processes.ProcessBuilder` instance ready to be submitted.
         """
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals,too-many-branches
         from aiida_quantumespresso.common import types
         from qe_tools import CONSTANTS
 
@@ -151,6 +151,21 @@ class QuantumEspressoCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = types.ElectronicType(electronic_type)
+        else:
+            electronic_type = types.ElectronicType(electronic_type.value)
+
+        if isinstance(relax_type, str):
+            relax_type = types.RelaxType(relax_type)
+        else:
+            relax_type = types.RelaxType(relax_type.value)
+
+        if isinstance(spin_type, str):
+            spin_type = types.SpinType(spin_type)
+        else:
+            spin_type = types.SpinType(spin_type.value)
 
         if magnetization_per_site:
             kind_to_magnetization = set(zip([site.kind_name for site in structure.sites], magnetization_per_site))
@@ -175,9 +190,9 @@ class QuantumEspressoCommonRelaxInputGenerator(CommonRelaxInputGenerator):
                     }
                 },
             },
-            relax_type=types.RelaxType(relax_type.value),
-            electronic_type=types.ElectronicType(electronic_type.value),
-            spin_type=types.SpinType(spin_type.value),
+            relax_type=relax_type,
+            electronic_type=electronic_type,
+            spin_type=spin_type,
             initial_magnetic_moments=initial_magnetic_moments,
         )
 

--- a/aiida_common_workflows/workflows/relax/siesta/generator.py
+++ b/aiida_common_workflows/workflows/relax/siesta/generator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for SIESTA."""
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 
 import yaml
 
@@ -85,16 +85,16 @@ class SiestaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         with open(_filepath) as _thefile:
             self._protocols = yaml.full_load(_thefile)
 
-    def get_builder(  # pylint: disable=too-many-branches,too-many-locals
+    def get_builder(  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         self,
         structure: StructureData,
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -134,6 +134,15 @@ class SiestaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         # Checks
         if protocol not in self.get_protocol_names():

--- a/aiida_common_workflows/workflows/relax/vasp/generator.py
+++ b/aiida_common_workflows/workflows/relax/vasp/generator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for VASP."""
 import pathlib
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 
 import yaml
 
@@ -57,10 +57,10 @@ class VaspCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         engines: Dict[str, Any],
         *,
         protocol: str = None,
-        relax_type: RelaxType = RelaxType.POSITIONS,
-        electronic_type: ElectronicType = ElectronicType.METAL,
-        spin_type: SpinType = SpinType.NONE,
-        magnetization_per_site: List[float] = None,
+        relax_type: Union[RelaxType, str] = RelaxType.POSITIONS,
+        electronic_type: Union[ElectronicType, str] = ElectronicType.METAL,
+        spin_type: Union[SpinType, str] = SpinType.NONE,
+        magnetization_per_site: Union[List[float], Tuple[float]] = None,
         threshold_forces: float = None,
         threshold_stress: float = None,
         reference_workchain=None,
@@ -99,6 +99,15 @@ class VaspCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             reference_workchain=reference_workchain,
             **kwargs
         )
+
+        if isinstance(electronic_type, str):
+            electronic_type = ElectronicType(electronic_type)
+
+        if isinstance(relax_type, str):
+            relax_type = RelaxType(relax_type)
+
+        if isinstance(spin_type, str):
+            spin_type = SpinType(spin_type)
 
         # Get the protocol that we want to use
         if protocol is None:


### PR DESCRIPTION
Fixes #170 

Currently, the `get_builder` method required an Enum instance to be
passed for the `electronic_type`, `relax_type` and `spin_type` keyword
arugments. This requires the user to import the corresponding enums
which forces not just to add a line of code but also for them to know
where to import it from. From a user's perspective it is easier to just
be able to pass the string value as well.

The signature is updated to also accept a string. The downside is that
the implementation now first has to check the type. To prevent each
implementation having to do this, we add as much as possible of the
validation in the base class, however, it is not possible to change the
keyword argument values themselves. So we cannot ensure in the base
class to convert any str types to the corresponding enum. This forces
the implemetations to still perform this check and conversion
themselves, but at least they know that whatever value is received it is
a valid and supported enum value.