### PR TITLE
CLI: Add validation for `plot` commands

### DIFF
--- a/aiida_common_workflows/cli/plot.py
+++ b/aiida_common_workflows/cli/plot.py
@@ -37,7 +37,7 @@ def cmd_plot_eos(workflow, precisions, print_table, output_file):
         )
     outputs = workflow.get_outgoing(link_type=LinkType.RETURN).nested()
 
-    if any([output not in outputs for output in ('structures', 'total_energies')]):
+    if any(output not in outputs for output in ('structures', 'total_energies')):
         echo.echo_critical(f'node {workflow.__class__.__name__}<{workflow.pk}> does not have the required outputs.')
 
     volumes = []
@@ -102,11 +102,11 @@ def cmd_plot_dissociation_curve(workflow, precisions, print_table, output_file):
 
     if workflow.process_class is not DissociationCurveWorkChain:
         echo.echo_critical(
-            f'node {workflow.__class__.__name__}<{workflow.pk}> does not represent a DissociationCurveWorkChain.'
+            f'node {workflow.__class__.__name__}<{workflow.pk}> does not correspond to a DissociationCurveWorkChain.'
         )
     outputs = workflow.get_outgoing(link_type=LinkType.RETURN).nested()
 
-    if any([output not in outputs for output in ('distances', 'total_energies')]):
+    if any(output not in outputs for output in ('distances', 'total_energies')):
         echo.echo_critical(f'node {workflow.__class__.__name__}<{workflow.pk}> does not have the required outputs.')
 
     distances = []

--- a/aiida_common_workflows/cli/plot.py
+++ b/aiida_common_workflows/cli/plot.py
@@ -32,11 +32,13 @@ def cmd_plot_eos(workflow, precisions, print_table, output_file):
     from aiida_common_workflows.common.visualization.eos import get_eos_plot
 
     if workflow.process_class is not EquationOfStateWorkChain:
-        echo.echo_critical(f'Provided workflow with PK {workflow.pk} does not represent an EquationOfStateWorkChain.')
-    if workflow.exit_status != 0:
-        echo.echo_critical(f'Provided workflow with PK {workflow.pk} did not finish successfully.')
-
+        echo.echo_critical(
+            f'node {workflow.__class__.__name__}<{workflow.pk}> does not correspond to an EquationOfStateWorkChain.'
+        )
     outputs = workflow.get_outgoing(link_type=LinkType.RETURN).nested()
+
+    if any([output not in outputs for output in ('structures', 'total_energies')]):
+        echo.echo_critical(f'node {workflow.__class__.__name__}<{workflow.pk}> does not have the required outputs.')
 
     volumes = []
     energies = []
@@ -99,11 +101,13 @@ def cmd_plot_dissociation_curve(workflow, precisions, print_table, output_file):
     from aiida_common_workflows.common.visualization.dissociation import get_dissociation_plot
 
     if workflow.process_class is not DissociationCurveWorkChain:
-        echo.echo_critical(f'Provided workflow with PK {workflow.pk} does not represent a DissociationCurveWorkChain.')
-    if workflow.exit_status != 0:
-        echo.echo_critical(f'Provided workflow with PK {workflow.pk} did not finish successfully.')
-
+        echo.echo_critical(
+            f'node {workflow.__class__.__name__}<{workflow.pk}> does not represent a DissociationCurveWorkChain.'
+        )
     outputs = workflow.get_outgoing(link_type=LinkType.RETURN).nested()
+
+    if any([output not in outputs for output in ('distances', 'total_energies')]):
+        echo.echo_critical(f'node {workflow.__class__.__name__}<{workflow.pk}> does not have the required outputs.')
 
     distances = []
     energies = []

--- a/aiida_common_workflows/cli/plot.py
+++ b/aiida_common_workflows/cli/plot.py
@@ -38,7 +38,10 @@ def cmd_plot_eos(workflow, precisions, print_table, output_file):
     outputs = workflow.get_outgoing(link_type=LinkType.RETURN).nested()
 
     if any(output not in outputs for output in ('structures', 'total_energies')):
-        echo.echo_critical(f'node {workflow.__class__.__name__}<{workflow.pk}> does not have the required outputs.')
+        missing_outputs = tuple(output for output in ('structures', 'total_energies') if output not in outputs)
+        echo.echo_critical(
+            f'node {workflow.__class__.__name__}<{workflow.pk}> is missing required outputs: {missing_outputs}'
+        )
 
     volumes = []
     energies = []
@@ -107,7 +110,10 @@ def cmd_plot_dissociation_curve(workflow, precisions, print_table, output_file):
     outputs = workflow.get_outgoing(link_type=LinkType.RETURN).nested()
 
     if any(output not in outputs for output in ('distances', 'total_energies')):
-        echo.echo_critical(f'node {workflow.__class__.__name__}<{workflow.pk}> does not have the required outputs.')
+        missing_outputs = tuple(output for output in ('distances', 'total_energies') if output not in outputs)
+        echo.echo_critical(
+            f'node {workflow.__class__.__name__}<{workflow.pk}> is missing required outputs: {missing_outputs}'
+        )
 
     distances = []
     energies = []

--- a/aiida_common_workflows/cli/plot.py
+++ b/aiida_common_workflows/cli/plot.py
@@ -37,8 +37,8 @@ def cmd_plot_eos(workflow, precisions, print_table, output_file):
         )
     outputs = workflow.get_outgoing(link_type=LinkType.RETURN).nested()
 
-    if any(output not in outputs for output in ('structures', 'total_energies')):
-        missing_outputs = tuple(output for output in ('structures', 'total_energies') if output not in outputs)
+    missing_outputs = tuple(output for output in ('structures', 'total_energies') if output not in outputs)
+    if missing_outputs:
         echo.echo_critical(
             f'node {workflow.__class__.__name__}<{workflow.pk}> is missing required outputs: {missing_outputs}'
         )
@@ -109,8 +109,8 @@ def cmd_plot_dissociation_curve(workflow, precisions, print_table, output_file):
         )
     outputs = workflow.get_outgoing(link_type=LinkType.RETURN).nested()
 
-    if any(output not in outputs for output in ('distances', 'total_energies')):
-        missing_outputs = tuple(output for output in ('distances', 'total_energies') if output not in outputs)
+    missing_outputs = tuple(output for output in ('distances', 'total_energies') if output not in outputs)
+    if missing_outputs:
         echo.echo_critical(
             f'node {workflow.__class__.__name__}<{workflow.pk}> is missing required outputs: {missing_outputs}'
         )

--- a/aiida_common_workflows/common/visualization/dissociation.py
+++ b/aiida_common_workflows/common/visualization/dissociation.py
@@ -20,7 +20,7 @@ def get_dissociation_plot(
     """
     if len(distances) != len(energies):
         raise ValueError('`distances` and `energies` are not of the same length.')
-    if not all([isinstance(d, float) for d in distances]):
+    if any(not isinstance(d, float) for d in distances):
         raise ValueError('not all values provided in `distances` are of type `float`.')
     if not all([isinstance(e, float) for e in energies]):
         raise ValueError('not all values provided in `energies` are of type `float`.')

--- a/aiida_common_workflows/common/visualization/dissociation.py
+++ b/aiida_common_workflows/common/visualization/dissociation.py
@@ -22,7 +22,7 @@ def get_dissociation_plot(
         raise ValueError('`distances` and `energies` are not of the same length.')
     if any(not isinstance(d, float) for d in distances):
         raise ValueError('not all values provided in `distances` are of type `float`.')
-    if not all([isinstance(e, float) for e in energies]):
+    if any(not isinstance(e, float) for e in energies):
         raise ValueError('not all values provided in `energies` are of type `float`.')
 
     plt.plot(distances, energies, 'o-')

--- a/aiida_common_workflows/common/visualization/dissociation.py
+++ b/aiida_common_workflows/common/visualization/dissociation.py
@@ -18,6 +18,13 @@ def get_dissociation_plot(
     :param unit_distance: unit of volume, default is [Å^3].
     :param unit_energy: unit of energy, default is [eV].
     """
+    assert len(distances) == len(energies), \
+        '`distances` and `energies` are not of the same length.'
+    assert all([isinstance(d, float) for d in distances]), \
+        'not all values provided in `distances` are of type `float`.'
+    assert all([isinstance(e, float) for e in energies]), \
+        'not all values provided in `energies` are of type `float`.'
+
     plt.plot(distances, energies, 'o-')
 
     plt.xlabel(f'Distance [{unit_distance}]')

--- a/aiida_common_workflows/common/visualization/dissociation.py
+++ b/aiida_common_workflows/common/visualization/dissociation.py
@@ -18,12 +18,12 @@ def get_dissociation_plot(
     :param unit_distance: unit of volume, default is [Å^3].
     :param unit_energy: unit of energy, default is [eV].
     """
-    assert len(distances) == len(energies), \
-        '`distances` and `energies` are not of the same length.'
-    assert all([isinstance(d, float) for d in distances]), \
-        'not all values provided in `distances` are of type `float`.'
-    assert all([isinstance(e, float) for e in energies]), \
-        'not all values provided in `energies` are of type `float`.'
+    if len(distances) != len(energies):
+        raise ValueError('`distances` and `energies` are not of the same length.')
+    if not all([isinstance(d, float) for d in distances]):
+        raise ValueError('not all values provided in `distances` are of type `float`.')
+    if not all([isinstance(e, float) for e in energies]):
+        raise ValueError('not all values provided in `energies` are of type `float`.')
 
     plt.plot(distances, energies, 'o-')
 

--- a/aiida_common_workflows/common/visualization/eos.py
+++ b/aiida_common_workflows/common/visualization/eos.py
@@ -48,9 +48,9 @@ def get_eos_plot(
     """
     if len(volumes) != len(energies):
         raise ValueError('`distances` and `energies` are not of the same length.')
-    if not all([isinstance(v, float) for v in volumes]):
+    if any(not isinstance(v, float) for v in volumes):
         raise ValueError('not all values provided in `volumes` are of type `float`.')
-    if not all([isinstance(d, float) for d in energies]):
+    if any(not isinstance(d, float) for d in energies):
         raise ValueError('not all values provided in `energies` are of type `float`.')
 
     params, _ = fit_birch_murnaghan_params(numpy.array(volumes), numpy.array(energies))

--- a/aiida_common_workflows/common/visualization/eos.py
+++ b/aiida_common_workflows/common/visualization/eos.py
@@ -46,12 +46,12 @@ def get_eos_plot(
     :param unit_volume: unit of volume, default is [Å^3].
     :param unit_energy: unit of energy, default is [eV].
     """
-    assert len(volumes) == len(energies), \
-        '`distances` and `energies` are not of the same length.'
-    assert all([isinstance(v, float) for v in volumes]), \
-        'not all values provided in `volumes` are of type `float`.'
-    assert all([isinstance(d, float) for d in energies]), \
-        'not all values provided in `energies` are of type `float`.'
+    if len(volumes) != len(energies):
+        raise ValueError('`distances` and `energies` are not of the same length.')
+    if not all([isinstance(v, float) for v in volumes]):
+        raise ValueError('not all values provided in `volumes` are of type `float`.')
+    if not all([isinstance(d, float) for d in energies]):
+        raise ValueError('not all values provided in `energies` are of type `float`.')
 
     params, _ = fit_birch_murnaghan_params(numpy.array(volumes), numpy.array(energies))
 

--- a/aiida_common_workflows/common/visualization/eos.py
+++ b/aiida_common_workflows/common/visualization/eos.py
@@ -46,6 +46,13 @@ def get_eos_plot(
     :param unit_volume: unit of volume, default is [Å^3].
     :param unit_energy: unit of energy, default is [eV].
     """
+    assert len(volumes) == len(energies), \
+        '`distances` and `energies` are not of the same length.'
+    assert all([isinstance(v, float) for v in volumes]), \
+        'not all values provided in `volumes` are of type `float`.'
+    assert all([isinstance(d, float) for d in energies]), \
+        'not all values provided in `energies` are of type `float`.'
+
     params, _ = fit_birch_murnaghan_params(numpy.array(volumes), numpy.array(energies))
 
     volume_min = min(volumes)

--- a/tests/cli/test_plot.py
+++ b/tests/cli/test_plot.py
@@ -87,6 +87,26 @@ def test_plot_eos_precision(run_cli_command, generate_eos_node, precisions, data
 
 
 @pytest.mark.usefixtures('aiida_profile')
+def test_plot_eos_wrong_workchain(run_cli_command, generate_dissociation_curve_node):
+    """Test the `plot_eos` command in case the provided work chain is incorrect."""
+    node = generate_dissociation_curve_node().store()
+
+    options = [str(node.pk)]
+    result = run_cli_command(plot.cmd_plot_eos, options, raises=SystemExit)
+    assert 'does not correspond to an EquationOfStateWorkChain' in result.output
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_plot_eos_missing_outputs(run_cli_command, generate_eos_node):
+    """Test the `plot_eos` command in case the provided work chain is missing outputs."""
+    node = generate_eos_node(include_energy=False).store()
+
+    options = [str(node.pk)]
+    result = run_cli_command(plot.cmd_plot_eos, options, raises=SystemExit)
+    assert 'is missing required outputs: (\'total_energies\',)' in result.output
+
+
+@pytest.mark.usefixtures('aiida_profile')
 def test_plot_dissociation_curve(run_cli_command, generate_dissociation_curve_node, monkeypatch):
     """Test the `plot_dissociation_curve` command.
 
@@ -103,16 +123,6 @@ def test_plot_dissociation_curve(run_cli_command, generate_dissociation_curve_no
     node = generate_dissociation_curve_node().store()
     options = [str(node.pk)]
     run_cli_command(plot.cmd_plot_dissociation_curve, options)
-
-
-@pytest.mark.usefixtures('aiida_profile')
-def test_plot_eos_wrong_workchain(run_cli_command, generate_dissociation_curve_node):
-    """Test the `plot_eos` command in case the provided work chain is incorrect."""
-    node = generate_dissociation_curve_node().store()
-
-    options = [str(node.pk)]
-    result = run_cli_command(plot.cmd_plot_eos, options, raises=SystemExit)
-    assert 'does not correspond to an EquationOfStateWorkChain' in result.output
 
 
 @pytest.mark.usefixtures('aiida_profile')
@@ -176,7 +186,7 @@ def test_plot_dissociation_curve_wrong_workchain(run_cli_command, generate_eos_n
 
 @pytest.mark.usefixtures('aiida_profile')
 def test_plot_dissociation_curve_missing_outputs(run_cli_command, generate_dissociation_curve_node):
-    """Test the `plot_dissociation_curve` command in case the provided work chain is incorrect."""
+    """Test the `plot_dissociation_curve` command in case the provided work chain is missing outputs."""
     node = generate_dissociation_curve_node(include_energy=False).store()
 
     options = [str(node.pk)]

--- a/tests/cli/test_plot.py
+++ b/tests/cli/test_plot.py
@@ -169,6 +169,16 @@ def test_plot_dissociation_curve_wrong_workchain(run_cli_command, generate_eos_n
     """Test the `plot_dissociation_curve` command in case the provided work chain is incorrect."""
     node = generate_eos_node().store()
 
-    options = [str(node.pk)
+    options = [str(node.pk)]
     result = run_cli_command(plot.cmd_plot_dissociation_curve, options, raises=SystemExit)
     assert 'does not correspond to a DissociationCurveWorkChain' in result.output
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_plot_dissociation_curve_missing_outputs(run_cli_command, generate_dissociation_curve_node):
+    """Test the `plot_dissociation_curve` command in case the provided work chain is incorrect."""
+    node = generate_dissociation_curve_node(include_energy=False).store()
+
+    options = [str(node.pk)]
+    result = run_cli_command(plot.cmd_plot_dissociation_curve, options, raises=SystemExit)
+    assert 'is missing required outputs: (\'total_energies\',)' in result.output

--- a/tests/cli/test_plot.py
+++ b/tests/cli/test_plot.py
@@ -111,8 +111,8 @@ def test_plot_eos_wrong_workchain(run_cli_command, generate_dissociation_curve_n
     node = generate_dissociation_curve_node().store()
 
     options = [str(node.pk), '--print-table']
-    with pytest.raises(AssertionError):
-        run_cli_command(plot.cmd_plot_eos, options)
+    result = run_cli_command(plot.cmd_plot_eos, options, raises=SystemExit)
+    assert 'does not correspond to an EquationOfStateWorkChain' in result.output
 
 
 @pytest.mark.usefixtures('aiida_profile')
@@ -170,5 +170,5 @@ def test_plot_dissociation_curve_wrong_workchain(run_cli_command, generate_eos_n
     node = generate_eos_node().store()
 
     options = [str(node.pk), '--print-table']
-    with pytest.raises(AssertionError):
-        run_cli_command(plot.cmd_plot_dissociation_curve, options)
+    result = run_cli_command(plot.cmd_plot_dissociation_curve, options, raises=SystemExit)
+    assert 'does not correspond to a DissociationCurveWorkChain' in result.output

--- a/tests/cli/test_plot.py
+++ b/tests/cli/test_plot.py
@@ -110,7 +110,7 @@ def test_plot_eos_wrong_workchain(run_cli_command, generate_dissociation_curve_n
     """Test the `plot_eos` command in case the provided work chain is incorrect."""
     node = generate_dissociation_curve_node().store()
 
-    options = [str(node.pk), '--print-table']
+    options = [str(node.pk)]
     result = run_cli_command(plot.cmd_plot_eos, options, raises=SystemExit)
     assert 'does not correspond to an EquationOfStateWorkChain' in result.output
 
@@ -169,6 +169,6 @@ def test_plot_dissociation_curve_wrong_workchain(run_cli_command, generate_eos_n
     """Test the `plot_dissociation_curve` command in case the provided work chain is incorrect."""
     node = generate_eos_node().store()
 
-    options = [str(node.pk), '--print-table']
+    options = [str(node.pk)
     result = run_cli_command(plot.cmd_plot_dissociation_curve, options, raises=SystemExit)
     assert 'does not correspond to a DissociationCurveWorkChain' in result.output

--- a/tests/cli/test_plot.py
+++ b/tests/cli/test_plot.py
@@ -106,6 +106,16 @@ def test_plot_dissociation_curve(run_cli_command, generate_dissociation_curve_no
 
 
 @pytest.mark.usefixtures('aiida_profile')
+def test_plot_eos_wrong_workchain(run_cli_command, generate_dissociation_curve_node):
+    """Test the `plot_eos` command in case the provided work chain is incorrect."""
+    node = generate_dissociation_curve_node().store()
+
+    options = [str(node.pk), '--print-table']
+    with pytest.raises(AssertionError):
+        run_cli_command(plot.cmd_plot_eos, options)
+
+
+@pytest.mark.usefixtures('aiida_profile')
 @pytest.mark.parametrize('precisions', ((8, 7),))
 def test_plot_dissociation_curve_print_table(
     run_cli_command, generate_dissociation_curve_node, precisions, data_regression
@@ -152,3 +162,13 @@ def test_plot_dissociation_curve_print_table_output_file(run_cli_command, genera
     result = run_cli_command(plot.cmd_plot_dissociation_curve, options)
     assert f'Success: Table saved to {output_file}' in result.output
     assert Path.exists(output_file)
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_plot_dissociation_curve_wrong_workchain(run_cli_command, generate_eos_node):
+    """Test the `plot_dissociation_curve` command in case the provided work chain is incorrect."""
+    node = generate_eos_node().store()
+
+    options = [str(node.pk), '--print-table']
+    with pytest.raises(AssertionError):
+        run_cli_command(plot.cmd_plot_dissociation_curve, options)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,8 @@ def generate_eos_node(generate_structure):
                 magnetization = Float(index).store()
                 magnetization.add_incoming(node, link_type=LinkType.RETURN, link_label=f'total_magnetizations__{index}')
 
+        node.set_exit_status(0)
+
         return node
 
     return _generate_eos_node
@@ -149,6 +151,8 @@ def generate_dissociation_curve_node():
             if include_magnetization:
                 magnetization = Float(index).store()
                 magnetization.add_incoming(node, link_type=LinkType.RETURN, link_label=f'total_magnetizations__{index}')
+
+        node.set_exit_status(0)
 
         return node
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def generate_code(aiida_localhost):
 def generate_eos_node(generate_structure):
     """Generate an instance of ``EquationOfStateWorkChain``."""
 
-    def _generate_eos_node(include_magnetization=True):
+    def _generate_eos_node(include_magnetization=True, include_energy=True):
         from aiida.common import LinkType
         from aiida.orm import Float, WorkflowNode
 
@@ -115,10 +115,11 @@ def generate_eos_node(generate_structure):
 
         for index in range(5):
             structure = generate_structure().store()
-            energy = Float(index).store()
-
             structure.add_incoming(node, link_type=LinkType.RETURN, link_label=f'structures__{index}')
-            energy.add_incoming(node, link_type=LinkType.RETURN, link_label=f'total_energies__{index}')
+
+            if include_energy:
+                energy = Float(index).store()
+                energy.add_incoming(node, link_type=LinkType.RETURN, link_label=f'total_energies__{index}')
 
             if include_magnetization:
                 magnetization = Float(index).store()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,7 @@ def generate_eos_node(generate_structure):
 def generate_dissociation_curve_node():
     """Generate an instance of ``DissociationCurveWorkChain``."""
 
-    def _generate_dissociation_curve_node(include_magnetization=True):
+    def _generate_dissociation_curve_node(include_magnetization=True, include_energy=True):
         from aiida.common import LinkType
         from aiida.orm import Float, WorkflowNode
 
@@ -143,10 +143,12 @@ def generate_dissociation_curve_node():
 
         for index in range(5):
             distance = Float(index / 10).store()
-            energy = Float(index).store()
-
             distance.add_incoming(node, link_type=LinkType.RETURN, link_label=f'distances__{index}')
-            energy.add_incoming(node, link_type=LinkType.RETURN, link_label=f'total_energies__{index}')
+
+            # `include_energy` can be set to False to test cases with missing outputs
+            if include_energy:
+                energy = Float(index).store()
+                energy.add_incoming(node, link_type=LinkType.RETURN, link_label=f'total_energies__{index}')
 
             if include_magnetization:
                 magnetization = Float(index).store()


### PR DESCRIPTION
Fixes #185

Add validation of the plot commands:

* Make sure the provided node is a workflow node.
* Make sure the work chain has the correct process class.
* Make sure the work chain has the required outputs.
* For the plotting methods, check that the distance/volumes have the
same length as the energies, and that both lists contain only floats.