### PR TITLE
README: add reference to online docs and remove duplicate info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,111 +1,9 @@
-# aiida-common-workflows
-This package provides reusable workflows with common interfaces, implemented in [AiiDA](https://www.aiida.net), to compute material properties using various quantum engines.
-The common workflows make it easy to compute a material property for a variety of quantum engines.
-The workflows and their protocols are implemented by experts of the various quantum engines guaranteeing results of a desired precision.
-On top of that, the workflows report their results according to the same unified schema, making comparing and reusing results trivial.
-For more details, please refer to the original [publication (doi:)]().
-
-## Available common workflows
-The common workflows can be subdivided into two categories:
-
- 1. Base common workflows
- 2. Composite common workflows
-
-The base common workflows are those that define a single common interface for a workflow that computes a common material property or performs a common operation.
-This interface can then be implemented for various quantum engines.
-The resulting common workflow can then be reused as a modular block to create higher-level workflows.
-As long as this composite workflow uses exclusively base common workflows, its interface will also be fully agnostic of the quantum engine used.
-
-The following table shows the currently available base common workflows and the entry point prefix, as well as the entry point name suffix for each quantum engine that implements it.
-
-Workflow  |  Entry point prefix        | Description                                  | ABINIT   | BigDFT   | CASTEP   | CP2K   | FLEUR   | Gaussian   | NWChem   | ORCA   | Quantum ESPRESSO   | SIESTA   | VASP
---------- | -------------------------- | -------------------------------------------- |--------- | -------- | -------- | ------ | ------- | ---------- | -------- | ------ | ------------------ | -------- | -------
-Relax     | `common_workflows.relax.`  | Optimize the geometry of a solid or molecule | `abinit` | `bigdft` | `castep` | `cp2k` | `fleur` | `gaussian` | `nwchem` | `orca` | `quantum_espresso` | `siesta` | `vasp`
-
-Using the base common workflows listed above, the following composite common workflows are provided by this package:
-
-Workflow                 | Entry point name                      | Base common workflows  | Description
------------------------- | ------------------------------------- | ---------------------- | ----------------------------------------------------------------
-Equation of state (EOS)  | `common_workflows.eos`                | Relax                  | Computes the equation of state of a solid.
-Dissociation curve (DC)  | `common_workflows.dissociation_curve` | Relax                  | Computes the dissociation curve of a diatomic molecule.
-
-## How to use the common workflows
-To launch a common workflow, there are two main methods:
-
- * Use the built-in command line interface (CLI) utility
- * Write a custom launch script
-
-The first option is the simplest option to get started, however, it is not necessarily available for all common workflows and it does not expose the full functionality.
-For example, if you want to optimize the geometry of a crystal structure using the CLI, you can run the following command:
-
-    aiida-common-workflows launch relax -S <STRUCTURE> -X <CODE>  -- <ENGINE>
-
-Here, the `<STRUCTURE>` should be replaced with the [AiiDA identifier](https://aiida-core.readthedocs.io/en/latest/topics/cli.html#topics-cli-identifiers) of the [`StructureData`](https://aiida-core.readthedocs.io/en/latest/topics/data_types.html#structuredata) that needs to be optimized, `<CODE>` with the identifier of the [`Code`](https://aiida-core.readthedocs.io/en/latest/howto/run_codes.html#how-to-setup-a-code) that should be used and `<ENGINE>` the entry point name of the quantum engine whose workflow implementation should be employed.
-To determine what engine implementations are available, run the command with the `--help` flag:
-
-    aiida-common-workflows launch relax --help
-
-This will also provide information of all other available options.
-Although this command already provides quite a number of options in order to facilitate various use cases, it can never expose the full functionality.
-If more flexibility is required, it is advised to write a custom launch script, for example:
-
-```python
-from aiida.engine import submit
-from aiida.plugin import WorkflowFactory
-
-RelaxWorkChain = WorkflowFactory('common_workflows.relax.quantum_espresso')  # Load the relax workflow implementation of choice.
-
-structure = <STRUCTURE>  # A `StructureData` node representing the structure to be optimized.
-engines = {
-    'relax': {
-        'code': <CODE>,  # An identifier of a `Code` configured for the `quantumespresso.pw` plugin
-        'options': {
-            'resources': {
-                'num_machines': 1,  # Number of machines/nodes to use
-            },
-            'max_wallclock_seconds': 3600,  # Number of wallclock seconds to request from the scheduler for each job
-        }
-    }
-}
-
-builder = RelaxWorkChain.get_input_generator().get_builder(structure, engines)
-submit(builder)
-```
-
-The script essentially consists of four steps:
-
- 1. Load the workflow implementation for the desired quantum engine based on its [entry point name](https://aiida-core.readthedocs.io/en/latest/topics/plugins.html#what-is-an-entry-point).
-    To determine the available implementations, you can run the command `verdi plugin list aiida.workflows`.
-    Any entry point that starts with `common_workflows.relax.` can be used to run the common relax workflow.
-    The suffix denotes the quantum engine that underlies the implementation.
- 2. Define the required `structure` and `engines` inputs.
- 3. Retrieve the workflow builder instance for the given inputs.
-    This `get_builder` method will return a [process builder instance](https://aiida-core.readthedocs.io/en/latest/topics/processes/usage.html?highlight=ProcessBuilder#process-builder) that has all the necessary inputs defined based on the protocol of the input generator.
-    At this point, you are free to change any of these default inputs.
- 4. All that remains is to `submit` the builder to the daemon and the workflow will start to run (if the daemon is running).
-
-
-## Input protocols
-Each base common workflow provides an input generator that implements the common interface.
-The generator provides the `get_builder` method, which for a minimum set of required inputs, returns a process builder with all the required inputs defined and therefore is ready for submission.
-The inputs are determined by a "protocol" which represents the desired precision.
-For example, the common relax workflow provides at least the three protocols `fast`, `moderate` and `precise`.
-The `precise` protocol will select inputs that will yield calculations of a higher precision, at a higher computational cost.
-The `fast` protocol will be computationally cheaper but will also have reduced precision.
-
-To determine what protocols are available for a given workflow, you can call the `get_protocol_names` method in the input generator, for example:
-
-    RelaxWorkChain = WorkflowFactory('common_workflows.relax.quantum_espresso')
-    RelaxWorkChain.get_input_generator().get_protocol_names()
-
-The default protocol can be determined as follows:
-
-    RelaxWorkChain.get_input_generator().get_default_protocol_name()
-
-To use a different protocol for the generation of the inputs, simply pass it as an argument to the `get_builder` method:
-
-    RelaxWorkChain = WorkflowFactory('common_workflows.relax.quantum_espresso')
-    RelaxWorkChain.get_input_generator().get_builder(structure=..., engines=..., protocol='precise')
+# `aiida-common-workflows`
+The AiiDA common workflows project provides computational workflows, implemented in [AiiDA](https://www.aiida.net), to compute various material properties using any of the quantum engines that implement it.
+The distinguishing feature is that the interfaces of the AiiDA common workflows are uniform, independent of the quantum engine that is used underneath to perform the material property simulations.
+These common interfaces make it trivial to switch from quantum engine.
+In addition to the common interface, the workflows provide input generators that automatically define the required inputs for a given task and desired computational precision.
+For more information, please refer to the [online documentation](https://aiida-common-workflows.readthedocs.io/en/latest/).
 
 
 ## How to cite
@@ -114,14 +12,14 @@ In addition, one should cite the quantum engines whose implementations are used.
 
 Engine           | DOIs or URLs to be cited
 ---------------- | ----------------------------
-ABINIT           |
-BigDFT           |
-CASTEP           |
-CP2K             |
-FLEUR            |
+ABINIT           | [10.1016/j.cpc.2016.04.003](https://doi.org/10.1016/j.cpc.2016.04.003) [10.1016/j.cpc.2019.107042](https://doi.org/10.1016/j.cpc.2019.107042) [10.1063/1.5144261](https://doi.org/10.1063/1.5144261)
+BigDFT           | [10.1063/5.0004792](https://doi.org/10.1063/5.0004792)
+CASTEP           | [10.1524/zkri.220.5.567.65075](https://doi.org/10.1524/zkri.220.5.567.65075)
+CP2K             | [10.1002/wcms.1159](https://doi.org/10.1002/wcms.1159) [10.1063/5.0007045](https://doi.org/10.1063/5.0007045)
+FLEUR            | [https://www.flapw.de](https://www.flapw.de)
 Gaussian         |
-NWChem           |
-ORCA             |
-Quantum ESPRESSO |
-SIESTA           |
-VASP             |
+NWChem           | [10.1063/5.0004997](https://doi.org/10.1063/5.0004997)
+ORCA             | [10.1002/wcms.81](https://doi.org/10.1002/wcms.81) [10.1002/wcms.1327](https://doi.org/10.1002/wcms.1327)
+Quantum ESPRESSO | [10.1088/0953-8984/21/39/395502](https://doi.org/10.1088/0953-8984/21/39/395502) [10.1088/1361-648x/aa8f79](https://doi.org/10.1088/1361-648x/aa8f79)
+SIESTA           | [10.1063/5.0005077](https://doi.org/10.1063/5.0005077) [10.1088/0953-8984/14/11/302](https://doi.org/10.1088/0953-8984/14/11/302)
+VASP             | [10.1103/physrevb.54.11169](https://doi.org/10.1103/physrevb.54.11169)  [10.1103/physrevb.59.1758](https://doi.org/10.1103/physrevb.59.1758)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,9 +12,9 @@ AiiDA common workflows
    workflows/composite/index
 
 The AiiDA common workflows project provides computational workflows, implemented in `AiiDA`_, to compute various material properties using any of the quantum engines that implement it.
-The distinguishing feature is that the interfaces of the AiiDA common workflows are unique, independent of the quantum engine that is used underneath to perform the material property simulations.
+The distinguishing feature is that the interfaces of the AiiDA common workflows are uniform, independent of the quantum engine that is used underneath to perform the material property simulations.
 These common interfaces make it trivial to switch from quantum engine.
-In addition to the common interface, the workflows provide input generators that automatically define the required inputs for a given task.
+In addition to the common interface, the workflows provide input generators that automatically define the required inputs for a given task and desired computational precision.
 
 The common workflows can be subdivided into two categories:
 

--- a/docs/source/workflows/base/relax.rst
+++ b/docs/source/workflows/base/relax.rst
@@ -68,13 +68,13 @@ Only ``structure`` and ``engines`` can be specified as a positional argument, al
 
   .. code:: python
 
-        input_generator.get_engine_types()
+    input_generator.get_engine_types()
 
   For each ``engine_type`` (for instance ``inpgen`` of FLEUR), details on the required code and resources can be obtained with:
 
   .. code:: python
 
-        input_generator.get_engine_type_schema("inpgen")
+    input_generator.get_engine_type_schema("inpgen")
 
 
 * ``protocol``. (Type: a Python string).
@@ -93,9 +93,9 @@ Only ``structure`` and ``engines`` can be specified as a positional argument, al
 
   .. code:: python
 
-        input_generator.get_protocol_names()
-        input_generator.get_protocol('fast')  # Can replace 'fast' with any of the other available protocols
-        input_generator.get_default_protocol_name()
+    input_generator.get_protocol_names()
+    input_generator.get_protocol('fast')  # Can replace 'fast' with any of the other available protocols
+    input_generator.get_default_protocol_name()
 
 
 * ``relax_type``. (Type: a Python string).
@@ -110,7 +110,7 @@ Only ``structure`` and ``engines`` can be specified as a positional argument, al
 
   .. code:: python
 
-        input_generator.get_relax_types()
+    input_generator.get_relax_types()
 
 
 * ``threshold_forces``. (Type: a Python float).
@@ -132,7 +132,7 @@ Only ``structure`` and ``engines`` can be specified as a positional argument, al
 
   .. code:: python
 
-        input_generator.get_electronic_types()
+    input_generator.get_electronic_types()
 
 
 * ``spin_type``. (Type: a python string).
@@ -143,7 +143,7 @@ Only ``structure`` and ``engines`` can be specified as a positional argument, al
 
   .. code:: python
 
-        input_generator.get_spin_types()
+    input_generator.get_spin_types()
 
 
 * ``magnetization_per_site``. (Type: Python None or a Python list of floats).
@@ -208,7 +208,7 @@ The available ``<ENGINE>`` are:
 
 .. code:: console
 
-        [abinit|bigdft|castep|cp2k|fleur|gaussian|orca|quantum_espresso|siesta|vasp]
+    [abinit|bigdft|castep|cp2k|fleur|gaussian|orca|quantum_espresso|siesta|vasp]
 
 
 A list of options follows:

--- a/docs/source/workflows/composite/dc.rst
+++ b/docs/source/workflows/composite/dc.rst
@@ -7,8 +7,6 @@ The inputs for the single-point calculations can be defined in a code-agnostic w
 The only available option for the ``relax_type`` is ``none``, which corresponds to single-point calculations.
 To allow full flexibility on the inputs, code-dependent overrides can be specified through the input port ``sub_process`` (see below).
 
-
-
 Submission script template
 ..........................
 
@@ -36,7 +34,7 @@ A typical script for the submission of common DC workflow could look something l
         'sub_process' : {  # optional code-dependent overrides
             'parameters': Dict(dict={...})
             ...
-     },
+        },
     }
 
     submit(cls, **inputs)
@@ -101,24 +99,24 @@ A template script to retrieve the results follows:
 
 .. code:: python
 
-        from aiida.common import LinkType
+    from aiida.common import LinkType
 
-        node = load_node(<IDN>) # <IDN> is an identifier (PK, uuid, ..) of a completed DC workchain
+    node = load_node(<IDN>) # <IDN> is an identifier (PK, uuid, ..) of a completed DC workchain
 
-        outputs = node.get_outgoing(link_type=LinkType.RETURN).nested()
+    outputs = node.get_outgoing(link_type=LinkType.RETURN).nested()
 
-        distances = []
-        energies = []
-        magnetizations = []
+    distances = []
+    energies = []
+    magnetizations = []
 
-        for index in outputs['total_energies'].keys():
-            distances.append(outputs['distances'][index].value)
-            energies.append(outputs['total_energies'][index].value)
-            try:
-                total_magnetization = outputs['total_magnetizations'][index].value
-            except KeyError:
-                total_magnetization = None
-            magnetizations.append(total_magnetization)
+    for index in outputs['total_energies'].keys():
+        distances.append(outputs['distances'][index].value)
+        energies.append(outputs['total_energies'][index].value)
+        try:
+            total_magnetization = outputs['total_magnetizations'][index].value
+        except KeyError:
+            total_magnetization = None
+        magnetizations.append(total_magnetization)
 
 
 
@@ -130,7 +128,7 @@ For the DC workflow:
 
 .. code:: console
 
-    aiida-common-workflows launch dissociation-curve <OPTIONS>  -- <ENGINE>
+    aiida-common-workflows launch dissociation-curve <OPTIONS> -- <ENGINE>
 
 The available ``<ENGINE>`` and ``<OPTIONS>`` are the same of the :ref:`relaxation CLI <relax-cli>`, with the exception of the ``-P`` and ``-r`` option.
 

--- a/docs/source/workflows/composite/eos.rst
+++ b/docs/source/workflows/composite/eos.rst
@@ -6,7 +6,6 @@ The inputs for the relaxation can be defined in a code-agnostic way, making use 
 Relaxation types with variable volume are forbidden.
 To allow full flexibility on the inputs, code-dependent overrides can be specified through the input port ``sub_process`` (see below).
 
-
 Submission script template
 ..........................
 
@@ -33,7 +32,7 @@ A typical script for the submission of common EoS workflow could look something 
         'sub_process' : {  # optional code-dependent overrides
             'parameters' : Dict(dict={...})
             ...
-     },
+        },
     }
 
     submit(cls, **inputs)
@@ -100,24 +99,24 @@ A template script to retrieve the results follows:
 
 .. code:: python
 
-        from aiida.common import LinkType
+    from aiida.common import LinkType
 
-        node = load_node(<IDN>) # <IDN> is an identifier (PK, uuid, ..) of a completed EoS workchain
+    node = load_node(<IDN>) # <IDN> is an identifier (PK, uuid, ..) of a completed EoS workchain
 
-        outputs = node.get_outgoing(link_type=LinkType.RETURN).nested()
+    outputs = node.get_outgoing(link_type=LinkType.RETURN).nested()
 
-        volumes = []
-        energies = []
-        magnetizations = []
+    volumes = []
+    energies = []
+    magnetizations = []
 
-        for index in outputs['total_energies'].keys():
-            volumes.append(outputs['structures'][index].get_cell_volume())
-            energies.append(outputs['total_energies'][index].value)
-            try:
-                total_magnetization = outputs['total_magnetizations'][index].value
-            except KeyError:
-                total_magnetization = None
-            magnetizations.append(total_magnetization)
+    for index in outputs['total_energies'].keys():
+        volumes.append(outputs['structures'][index].get_cell_volume())
+        energies.append(outputs['total_energies'][index].value)
+        try:
+            total_magnetization = outputs['total_magnetizations'][index].value
+        except KeyError:
+            total_magnetization = None
+        magnetizations.append(total_magnetization)
 
 CLI
 ...
@@ -127,7 +126,7 @@ For the eos workflow:
 
 .. code:: console
 
-    aiida-common-workflows launch eos <OPTIONS>  -- <ENGINE>
+    aiida-common-workflows launch eos <OPTIONS> -- <ENGINE>
 
 The available ``<ENGINE>`` and ``<OPTIONS>`` are the same of the :ref:`relaxation CLI <relax-cli>`, with the exception of the ``-P`` option and a limitation on the allowed relaxation types.
 


### PR DESCRIPTION
The citations of the various codes are kept in the README for now. At
some point these also need to go in the docs. There is no citation with
a DOI for Gaussian, so no canonical link, so not sure what to link.