### PR TITLE
CI: install the package normally without editable flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
                 python-version: 3.8
 
         -   name: Install python dependencies
-            run: pip install -e .[pre-commit,tests]
+            run: pip install .[pre-commit,tests]
 
         -   name: Run pre-commit
             run:
@@ -61,7 +61,7 @@ jobs:
         -   name: Install python dependencies
             run: |
                 pip install --upgrade setuptools
-                pip install -e .[tests]
+                pip install .[tests]
                 reentry scan
 
         -   name: Run pytest

--- a/setup.json
+++ b/setup.json
@@ -59,14 +59,15 @@
             "aiida-common-workflows = aiida_common_workflows.cli:cmd_root"
         ],
         "aiida.workflows": [
-            "common_workflows.eos = aiida_common_workflows.workflows.eos:EquationOfStateWorkChain",
             "common_workflows.dissociation_curve = aiida_common_workflows.workflows.dissociation:DissociationCurveWorkChain",
+            "common_workflows.eos = aiida_common_workflows.workflows.eos:EquationOfStateWorkChain",
             "common_workflows.relax.abinit = aiida_common_workflows.workflows.relax.abinit.workchain:AbinitCommonRelaxWorkChain",
             "common_workflows.relax.bigdft = aiida_common_workflows.workflows.relax.bigdft.workchain:BigDftCommonRelaxWorkChain",
             "common_workflows.relax.castep = aiida_common_workflows.workflows.relax.castep.workchain:CastepCommonRelaxWorkChain",
             "common_workflows.relax.cp2k = aiida_common_workflows.workflows.relax.cp2k.workchain:Cp2kCommonRelaxWorkChain",
             "common_workflows.relax.fleur = aiida_common_workflows.workflows.relax.fleur.workchain:FleurCommonRelaxWorkChain",
             "common_workflows.relax.gaussian = aiida_common_workflows.workflows.relax.gaussian.workchain:GaussianCommonRelaxWorkChain",
+            "common_workflows.relax.nwchem = aiida_common_workflows.workflows.relax.nwchem.workchain:NwchemCommonRelaxWorkChain",
             "common_workflows.relax.orca = aiida_common_workflows.workflows.relax.orca.workchain:OrcaCommonRelaxWorkChain",
             "common_workflows.relax.quantum_espresso = aiida_common_workflows.workflows.relax.quantum_espresso.workchain:QuantumEspressoCommonRelaxWorkChain",
             "common_workflows.relax.siesta = aiida_common_workflows.workflows.relax.siesta.workchain:SiestaCommonRelaxWorkChain",


### PR DESCRIPTION
The `-e` flag for `pip install` installs the package in editable mode,
meaning that the repository is simply symlinked into the virtual
environment such that changes to the code are picked up. This is useful
during development, however, for testing it is not necessary, but worse,
it can hide bugs with the definition of the package. For example,
non-python files that have to be shipped with the package, for example
yaml configuration files, need to be properly defined in `MANIFEST.in`
or else they will be missing in the distribution. By using an editable
install, these mistakes won't be noticed, since these files will always
be available directly from the repository.