### PR TITLE
CI: add testing for common relax input generator and input spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     tests:
 
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 30
 
         strategy:
             matrix:

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -116,7 +116,15 @@ class AbinitCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         protocol = copy.deepcopy(self.get_protocol(protocol))
         code = engines['relax']['code']
 
-        pseudo_family = orm.Group.objects.get(label=protocol.pop('pseudo_family'))
+        pseudo_family_label = protocol.pop('pseudo_family')
+        try:
+            pseudo_family = orm.Group.objects.get(label=pseudo_family_label)
+        except exceptions.NotExistent as exception:
+            raise ValueError(
+                f'required pseudo family `{pseudo_family_label}` is not installed. '
+                'Please use `aiida-pseudo install pseudo-dojo` to install it.'
+            ) from exception
+
         cutoff_stringency = protocol['cutoff_stringency']
         pseudo_type = pseudo_family.pseudo_type
         recommended_ecut_wfc, recommended_ecut_rho = pseudo_family.get_recommended_cutoffs(
@@ -246,6 +254,9 @@ class AbinitCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             else:
                 raise ValueError(f'Initial magnetization {magnetization_per_site} is ambiguous')
         elif spin_type == SpinType.NON_COLLINEAR:
+            if magnetization_per_site is None:
+                magnetization_per_site = get_initial_magnetization(structure)
+                warnings.warn(f'input magnetization per site was None, setting it to {magnetization_per_site}')
             # LATER: support vector magnetization_per_site
             builder.abinit['parameters']['nspinor'] = 2  # w.f. as spinors
             builder.abinit['parameters']['nsppol'] = 1  # spin-up and spin-down can't be disentangled
@@ -382,7 +393,7 @@ def recursive_merge(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, An
     """
     for key, value in left.items():
         if key in right:
-            if isinstance(value, collections.Mapping) and isinstance(right[key], collections.Mapping):
+            if isinstance(value, collections.abc.Mapping) and isinstance(right[key], collections.abc.Mapping):
                 right[key] = recursive_merge(value, right[key])
 
     merged = left.copy()

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -264,7 +264,7 @@ def recursive_merge(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, An
     """
     for key, value in left.items():
         if key in right:
-            if isinstance(value, collections.Mapping) and isinstance(right[key], collections.Mapping):
+            if isinstance(value, collections.abc.Mapping) and isinstance(right[key], collections.abc.Mapping):
                 # Here, the right dictionary is modified in-place and contains the merged items
                 right[key] = recursive_merge(value, right[key])
 

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -32,7 +32,7 @@ def dict_merge(dct, merge_dct):
     :return: None
     """
     for k in merge_dct.keys():
-        if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.Mapping)):
+        if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.abc.Mapping)):
             dict_merge(dct[k], merge_dct[k])
         else:
             dct[k] = merge_dct[k]

--- a/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -373,7 +373,7 @@ def recursive_merge(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, An
     """
     for key, value in left.items():
         if key in right:
-            if isinstance(value, collections.Mapping) and isinstance(right[key], collections.Mapping):
+            if isinstance(value, collections.abc.Mapping) and isinstance(right[key], collections.abc.Mapping):
                 right[key] = recursive_merge(value, right[key])
 
     merged = left.copy()

--- a/aiida_common_workflows/workflows/relax/orca/generator.py
+++ b/aiida_common_workflows/workflows/relax/orca/generator.py
@@ -117,7 +117,7 @@ class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
 
         # Checks
         if any(structure.get_attribute_many(['pbc1', 'pbc2', 'pbc2'])):
-            warnings.warn('Warning: PBC detected in the input structure. It is not supported and thus is ignored.')
+            warnings.warn('PBC detected in the input structure. It is not supported and thus is ignored.')
 
         if protocol not in self.get_protocol_names():
             warnings.warn('no protocol implemented with name {}, using default moderate'.format(protocol))
@@ -154,9 +154,7 @@ class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             if magnetization_per_site is None:
                 multiplicity_guess = 1
             else:
-                warnings.warn(
-                    'Warning: magnetization_per_site site-resolved info is disregarded, only total spin is processed.'
-                )
+                warnings.warn('magnetization_per_site site-resolved info is disregarded, only total spin is processed.')
                 # magnetization_per_site are in units of [Bohr magnetons] (*0.5 to get in [au])
                 total_spin_guess = 0.5 * np.abs(np.sum(magnetization_per_site))
                 multiplicity_guess = 2 * total_spin_guess + 1

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -7,7 +7,6 @@ from aiida_common_workflows.cli import launch
 from aiida_common_workflows.cli import utils
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_relax_wallclock_seconds(run_cli_command, generate_structure, generate_code):
     """Test the `--wallclock-seconds` option."""
     structure = generate_structure().store()
@@ -20,7 +19,6 @@ def test_relax_wallclock_seconds(run_cli_command, generate_structure, generate_c
            'requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_relax_number_machines(run_cli_command, generate_structure, generate_code):
     """Test the `--number-machines` option."""
     structure = generate_structure().store()
@@ -33,7 +31,6 @@ def test_relax_number_machines(run_cli_command, generate_structure, generate_cod
            'requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_relax_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
     """Test the `--number-mpi-procs-per-machine` option."""
     structure = generate_structure().store()
@@ -48,7 +45,7 @@ def test_relax_number_mpi_procs_per_machine(run_cli_command, generate_structure,
            'steps, so requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
+@pytest.mark.usefixtures('with_clean_database')
 def test_relax_codes(run_cli_command, generate_structure, generate_code, monkeypatch):
     """Test the `--codes` option."""
 
@@ -75,7 +72,6 @@ def test_relax_codes(run_cli_command, generate_structure, generate_code, monkeyp
     result = run_cli_command(launch.cmd_relax, options)
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_eos_wallclock_seconds(run_cli_command, generate_structure, generate_code):
     """Test the `--wallclock-seconds` option."""
     structure = generate_structure().store()
@@ -88,7 +84,6 @@ def test_eos_wallclock_seconds(run_cli_command, generate_structure, generate_cod
            'requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_eos_number_machines(run_cli_command, generate_structure, generate_code):
     """Test the `--number-machines` option."""
     structure = generate_structure().store()
@@ -101,7 +96,6 @@ def test_eos_number_machines(run_cli_command, generate_structure, generate_code)
            'requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_eos_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
     """Test the `--number-mpi-procs-per-machine` option."""
     structure = generate_structure().store()
@@ -116,7 +110,6 @@ def test_eos_number_mpi_procs_per_machine(run_cli_command, generate_structure, g
            'steps, so requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_eos_relax_types(run_cli_command, generate_structure, generate_code):
     """Test the `--relax-type` option."""
     structure = generate_structure().store()
@@ -129,7 +122,6 @@ def test_eos_relax_types(run_cli_command, generate_structure, generate_code):
             '(choose from none, positions, shape, positions_shape)' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_dissociation_curve_wallclock_seconds(run_cli_command, generate_structure, generate_code):
     """Test the `--wallclock-seconds` option."""
     structure = generate_structure().store()
@@ -142,7 +134,6 @@ def test_dissociation_curve_wallclock_seconds(run_cli_command, generate_structur
            'requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_dissociation_curve_number_machines(run_cli_command, generate_structure, generate_code):
     """Test the `--number-machines` option."""
     structure = generate_structure().store()
@@ -155,7 +146,6 @@ def test_dissociation_curve_number_machines(run_cli_command, generate_structure,
            'requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_dissociation_curve_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
     """Test the `--number-mpi-procs-per-machine` option."""
     structure = generate_structure().store()
@@ -170,7 +160,6 @@ def test_dissociation_curve_number_mpi_procs_per_machine(run_cli_command, genera
            'steps, so requires 1 values' in result.output_lines
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_relax_magn_per_type(run_cli_command, generate_structure, generate_code):
     """Test the `--magnetization-per-site` option."""
     structure = generate_structure()

--- a/tests/cli/test_plot.py
+++ b/tests/cli/test_plot.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 from aiida_common_workflows.cli import plot
 
 
-@pytest.mark.usefixtures('aiida_profile')
 @pytest.mark.parametrize('include_magnetization', (True, False))
 def test_plot_eos(run_cli_command, generate_eos_node, include_magnetization, monkeypatch):
     """Test the `plot_eos` command.
@@ -28,7 +27,6 @@ def test_plot_eos(run_cli_command, generate_eos_node, include_magnetization, mon
     run_cli_command(plot.cmd_plot_eos, options)
 
 
-@pytest.mark.usefixtures('aiida_profile')
 @pytest.mark.parametrize('include_magnetization', (True, False))
 def test_plot_eos_output_file(run_cli_command, generate_eos_node, include_magnetization, monkeypatch, tmp_path):
     """Test the `plot_eos` command with the `--output-file` option."""
@@ -48,7 +46,6 @@ def test_plot_eos_output_file(run_cli_command, generate_eos_node, include_magnet
     assert Path.exists(output_file)
 
 
-@pytest.mark.usefixtures('aiida_profile')
 @pytest.mark.parametrize('include_magnetization', (True, False))
 def test_plot_eos_print_table(run_cli_command, generate_eos_node, include_magnetization, data_regression):
     """Test the `plot_eos` command with the `--print-table` option."""
@@ -58,7 +55,6 @@ def test_plot_eos_print_table(run_cli_command, generate_eos_node, include_magnet
     data_regression.check({'output_lines': result.output_lines})
 
 
-@pytest.mark.usefixtures('aiida_profile')
 @pytest.mark.parametrize('include_magnetization', (True, False))
 def test_plot_eos_print_table_output_file(run_cli_command, generate_eos_node, include_magnetization, tmp_path):
     """Test the `plot_eos` command with the `--print-table` and `--output-file` options."""
@@ -72,7 +68,6 @@ def test_plot_eos_print_table_output_file(run_cli_command, generate_eos_node, in
     assert Path.exists(output_file)
 
 
-@pytest.mark.usefixtures('aiida_profile')
 @pytest.mark.parametrize('precisions', ((8,), (8, 7), (8, 7, 6), (8, 7, 6, 5)))
 def test_plot_eos_precision(run_cli_command, generate_eos_node, precisions, data_regression):
     """Test the `plot_eos` command with the `--precisions` option.
@@ -86,7 +81,6 @@ def test_plot_eos_precision(run_cli_command, generate_eos_node, precisions, data
     data_regression.check({'output_lines': result.output_lines})
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_plot_eos_wrong_workchain(run_cli_command, generate_dissociation_curve_node):
     """Test the `plot_eos` command in case the provided work chain is incorrect."""
     node = generate_dissociation_curve_node().store()
@@ -96,7 +90,6 @@ def test_plot_eos_wrong_workchain(run_cli_command, generate_dissociation_curve_n
     assert 'does not correspond to an EquationOfStateWorkChain' in result.output
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_plot_eos_missing_outputs(run_cli_command, generate_eos_node):
     """Test the `plot_eos` command in case the provided work chain is missing outputs."""
     node = generate_eos_node(include_energy=False).store()
@@ -106,7 +99,6 @@ def test_plot_eos_missing_outputs(run_cli_command, generate_eos_node):
     assert 'is missing required outputs: (\'total_energies\',)' in result.output
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_plot_dissociation_curve(run_cli_command, generate_dissociation_curve_node, monkeypatch):
     """Test the `plot_dissociation_curve` command.
 
@@ -125,7 +117,6 @@ def test_plot_dissociation_curve(run_cli_command, generate_dissociation_curve_no
     run_cli_command(plot.cmd_plot_dissociation_curve, options)
 
 
-@pytest.mark.usefixtures('aiida_profile')
 @pytest.mark.parametrize('precisions', ((8, 7),))
 def test_plot_dissociation_curve_print_table(
     run_cli_command, generate_dissociation_curve_node, precisions, data_regression
@@ -142,7 +133,6 @@ def test_plot_dissociation_curve_print_table(
     data_regression.check({'output_lines': result.output_lines})
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_plot_dissociation_curve_output_file(run_cli_command, generate_dissociation_curve_node, monkeypatch, tmp_path):
     """Test the `plot_dissociation_curve` command with the `--output-file` option."""
     from aiida_common_workflows.common.visualization import dissociation
@@ -161,7 +151,6 @@ def test_plot_dissociation_curve_output_file(run_cli_command, generate_dissociat
     assert Path.exists(output_file)
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_plot_dissociation_curve_print_table_output_file(run_cli_command, generate_dissociation_curve_node, tmp_path):
     """Test the `plot_dissociation_curve` command with the `--output-file` option."""
     node = generate_dissociation_curve_node().store()
@@ -174,7 +163,6 @@ def test_plot_dissociation_curve_print_table_output_file(run_cli_command, genera
     assert Path.exists(output_file)
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_plot_dissociation_curve_wrong_workchain(run_cli_command, generate_eos_node):
     """Test the `plot_dissociation_curve` command in case the provided work chain is incorrect."""
     node = generate_eos_node().store()
@@ -184,7 +172,6 @@ def test_plot_dissociation_curve_wrong_workchain(run_cli_command, generate_eos_n
     assert 'does not correspond to a DissociationCurveWorkChain' in result.output
 
 
-@pytest.mark.usefixtures('aiida_profile')
 def test_plot_dissociation_curve_missing_outputs(run_cli_command, generate_dissociation_curve_node):
     """Test the `plot_dissociation_curve` command in case the provided work chain is missing outputs."""
     node = generate_dissociation_curve_node(include_energy=False).store()

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 from aiida_common_workflows.cli.utils import get_code_from_list_or_database
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
+@pytest.mark.usefixtures('with_clean_database')
 def test_get_code_from_list_or_database(generate_code):
     """Test `get_code_from_list_or_database` method."""
     entry_point = 'quantumespresso.pw'

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,7 +1,10 @@
 [pytest]
 testpaths = tests
 filterwarnings =
+    ignore::DeprecationWarning:abipy:
+    ignore::DeprecationWarning:ase:
     ignore::DeprecationWarning:frozendict:
+    ignore::DeprecationWarning:past:
     ignore::DeprecationWarning:sqlalchemy_utils:
     ignore::DeprecationWarning:reentry:
     ignore::DeprecationWarning:pkg_resources:

--- a/tests/workflows/dissociation_curve/test_workchain_diss_curve.py
+++ b/tests/workflows/dissociation_curve/test_workchain_diss_curve.py
@@ -26,7 +26,6 @@ def common_relax_workchain(request) -> CommonRelaxWorkChain:
     return WorkflowFactory(request.param)
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_sub_process_class(ctx):
     """Test the `validate_sub_process_class` validator."""
     for value in [None, WorkChain]:
@@ -34,7 +33,6 @@ def test_validate_sub_process_class(ctx):
         assert dissociation.validate_sub_process_class(value, ctx) == message
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_sub_process_class_plugins(ctx, common_relax_workchain):
     """Test the `validate_sub_process_class` validator."""
     from aiida_common_workflows.plugins import get_entry_point_name_from_class
@@ -132,7 +130,6 @@ def test_validate_inputs_generator_inputs(ctx, generate_code, generate_structure
     assert "invalid_value' is not a valid SpinType" in dissociation.validate_inputs(value, ctx)
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_molecule(ctx, generate_structure):
     """Test the `validate_molecule` validator."""
     molecule = generate_structure()
@@ -142,17 +139,14 @@ def test_validate_molecule(ctx, generate_structure):
     assert dissociation.validate_molecule(molecule, ctx) is None
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_distances(ctx):
     """Test the `validate_scale_factors` validator."""
     assert dissociation.validate_distances(None, ctx) is None
     assert dissociation.validate_distances(orm.List(list=[0.98, 1, 1.02]), ctx) is None
-
     assert dissociation.validate_distances(orm.List(list=[0]), ctx) == 'need at least 2 distances.'
     assert dissociation.validate_distances(orm.List(list=[-1, -2, -2]), ctx) == 'distances must be positive.'
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_distances_count(ctx):
     """Test the `validate_scale_count` validator."""
     assert dissociation.validate_distances_count(None, ctx) is None
@@ -161,19 +155,15 @@ def test_validate_distances_count(ctx):
     assert dissociation.validate_distances_count(orm.Int(1), ctx) == 'need at least 2 distances.'
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_distance_max(ctx):
     """Test the `validate_distance_max` validator."""
     assert dissociation.validate_distance_max(None, ctx) is None
     assert dissociation.validate_distance_max(orm.Float(0.5), ctx) is None
-
     assert dissociation.validate_distance_max(orm.Float(-0.5), ctx) == '`distance_max` must be bigger than zero.'
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_distance_min(ctx):
     """Test the `validate_scale_increment` validator."""
     assert dissociation.validate_distance_min(None, ctx) is None
     assert dissociation.validate_distance_min(orm.Float(0.5), ctx) is None
-
     assert dissociation.validate_distance_min(orm.Float(-0.5), ctx) == '`distance_min` must be bigger than zero.'

--- a/tests/workflows/eos/test_workchain_eos.py
+++ b/tests/workflows/eos/test_workchain_eos.py
@@ -27,7 +27,6 @@ def common_relax_workchain(request) -> CommonRelaxWorkChain:
     return WorkflowFactory(request.param)
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_sub_process_class(ctx):
     """Test the `validate_sub_process_class` validator."""
     for value in [None, WorkChain]:
@@ -35,7 +34,6 @@ def test_validate_sub_process_class(ctx):
         assert eos.validate_sub_process_class(value, ctx) == message
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_sub_process_class_plugins(ctx, common_relax_workchain):
     """Test the `validate_sub_process_class` validator."""
     from aiida_common_workflows.plugins import get_entry_point_name_from_class
@@ -117,37 +115,30 @@ def test_validate_inputs_generator_inputs(ctx, generate_code, generate_structure
     assert "invalid_value' is not a valid ElectronicType" in eos.validate_inputs(value, ctx)
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_scale_factors(ctx):
     """Test the `validate_scale_factors` validator."""
     assert eos.validate_scale_factors(None, ctx) is None
     assert eos.validate_scale_factors(orm.List(list=[0.98, 1, 1.02]), ctx) is None
-
     assert eos.validate_scale_factors(orm.List(list=[0, 1]), ctx) == 'need at least 3 scaling factors.'
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_scale_count(ctx):
     """Test the `validate_scale_count` validator."""
     assert eos.validate_scale_count(None, ctx) is None
     assert eos.validate_scale_count(orm.Int(3), ctx) is None
-
     assert eos.validate_scale_count(orm.Int(2), ctx) == 'need at least 3 scaling factors.'
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_scale_increment(ctx):
     """Test the `validate_scale_increment` validator."""
     assert eos.validate_scale_increment(None, ctx) is None
     assert eos.validate_scale_increment(orm.Float(0.5), ctx) is None
-
     assert eos.validate_scale_increment(orm.Float(0), ctx) == 'scale increment needs to be between 0 and 1.'
     assert eos.validate_scale_increment(orm.Float(1), ctx) == 'scale increment needs to be between 0 and 1.'
     assert eos.validate_scale_increment(orm.Float(-0.0001), ctx) == 'scale increment needs to be between 0 and 1.'
     assert eos.validate_scale_increment(orm.Float(1.00001), ctx) == 'scale increment needs to be between 0 and 1.'
 
 
-@pytest.mark.usefixtures('with_database')
 def test_validate_relax_type(ctx):
     """Test the `validate_relax_type` validator."""
     assert eos.validate_relax_type(RelaxType.NONE, ctx) is None

--- a/tests/workflows/relax/test_abinit.py
+++ b/tests/workflows/relax/test_abinit.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.abinit` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.abinit')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('abinit').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+@pytest.mark.usefixtures('pseudo_dojo')
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('pseudo_dojo')
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+@pytest.mark.usefixtures('pseudo_dojo')
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('pseudo_dojo')
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('pseudo_dojo')
+@pytest.mark.filterwarnings('ignore: input magnetization per site was None')
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/relax/test_bigdft.py
+++ b/tests/workflows/relax/test_bigdft.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.bigdft` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.bigdft')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('bigdft').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/relax/test_castep.py
+++ b/tests/workflows/relax/test_castep.py
@@ -1,20 +1,24 @@
 # -*- coding: utf-8 -*-
-"""
-Tests from the generator
-"""
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.castep` module."""
 # pylint: disable=abstract-method,arguments-differ,redefined-outer-name,unused-argument
 import copy
 import pytest
+
+from aiida import engine
+from aiida import plugins
 from aiida.orm import StructureData
 from aiida.plugins import WorkflowFactory
-from ase.build.bulk import bulk
 from aiida_castep.data.otfg import OTFGGroup
+from ase.build.bulk import bulk
 
 from aiida_common_workflows.workflows.relax.castep.workchain import CastepCommonRelaxWorkChain
 from aiida_common_workflows.workflows.relax.castep.generator import (
     CastepCommonRelaxInputGenerator, generate_inputs, generate_inputs_base, generate_inputs_calculation,
     generate_inputs_relax, ensure_otfg_family, RelaxType, ElectronicType, SpinType
 )
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.castep')
+GENERATOR = WORKCHAIN.get_input_generator()
 
 
 @pytest.fixture
@@ -43,6 +47,71 @@ def castep_code(generate_code):
 def with_otfg(with_database):
     """Ensure has OTFG"""
     ensure_otfg_family('C19')
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('castep').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
 
 
 def test_calc_generator(nacl, castep_code, with_otfg):

--- a/tests/workflows/relax/test_cp2k.py
+++ b/tests/workflows/relax/test_cp2k.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.cp2k` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.cp2k')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('cp2k').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/relax/test_fleur.py
+++ b/tests/workflows/relax/test_fleur.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.fleur` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.fleur')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('fleur').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            },
+            'inpgen': {
+                'code': generate_code('fleur.inpgen').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/relax/test_gaussian.py
+++ b/tests/workflows/relax/test_gaussian.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.gaussian` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.gaussian')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('gaussian').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/relax/test_nwchem.py
+++ b/tests/workflows/relax/test_nwchem.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.nwchem` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.nwchem')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('nwchem').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/relax/test_orca.py
+++ b/tests/workflows/relax/test_orca.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.orca` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.orca')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('orca').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+@pytest.mark.filterwarnings('ignore: PBC detected ')
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.filterwarnings('ignore: PBC detected ')
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+@pytest.mark.filterwarnings('ignore: PBC detected ')
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.filterwarnings('ignore: PBC detected ')
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.filterwarnings('ignore: PBC detected ')
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/relax/test_quantum_espresso.py
+++ b/tests/workflows/relax/test_quantum_espresso.py
@@ -1,11 +1,86 @@
 # -*- coding: utf-8 -*-
-"""Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso.generator` module."""
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso` module."""
+# pylint: disable=redefined-outer-name
 import pytest
 
+from aiida import engine
+from aiida import plugins
 from qe_tools import CONSTANTS
 
-from aiida_common_workflows.workflows.relax.quantum_espresso.workchain import QuantumEspressoCommonRelaxWorkChain
 from aiida_common_workflows.workflows.relax.generator import ElectronicType, RelaxType, SpinType
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.quantum_espresso')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('quantumespresso.pw').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+@pytest.mark.usefixtures('sssp')
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('sssp')
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+@pytest.mark.usefixtures('sssp')
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('sssp')
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('sssp')
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
 
 
 @pytest.mark.usefixtures('sssp')
@@ -13,7 +88,7 @@ def test_relax_type(generate_code, generate_structure):
     """Test the ``relax_type`` keyword argument."""
     code = generate_code('quantum_espresso.pw')
     structure = generate_structure(symbols=('Si',))
-    generator = QuantumEspressoCommonRelaxWorkChain.get_input_generator()
+    generator = WORKCHAIN.get_input_generator()
     engines = {'relax': {'code': code, 'options': {}}}
 
     builder = generator.get_builder(structure, engines, relax_type=RelaxType.NONE)
@@ -52,7 +127,7 @@ def test_spin_type(generate_code, generate_structure):
     """Test the ``spin_type`` keyword argument."""
     code = generate_code('quantum_espresso.pw')
     structure = generate_structure(symbols=('Si',))
-    generator = QuantumEspressoCommonRelaxWorkChain.get_input_generator()
+    generator = WORKCHAIN.get_input_generator()
     engines = {'relax': {'code': code, 'options': {}}}
 
     builder = generator.get_builder(structure, engines, spin_type=SpinType.NONE)
@@ -68,7 +143,7 @@ def test_electronic_type(generate_code, generate_structure):
     """Test the ``electronic_type`` keyword argument."""
     code = generate_code('quantum_espresso.pw')
     structure = generate_structure(symbols=('Si',))
-    generator = QuantumEspressoCommonRelaxWorkChain.get_input_generator()
+    generator = WORKCHAIN.get_input_generator()
     engines = {'relax': {'code': code, 'options': {}}}
 
     builder = generator.get_builder(structure, engines, electronic_type=ElectronicType.METAL)
@@ -86,7 +161,7 @@ def test_threshold_forces(generate_code, generate_structure):
     """Test the ``threshold_forces`` keyword argument."""
     code = generate_code('quantum_espresso.pw')
     structure = generate_structure(symbols=('Si',))
-    generator = QuantumEspressoCommonRelaxWorkChain.get_input_generator()
+    generator = WORKCHAIN.get_input_generator()
     engines = {'relax': {'code': code, 'options': {}}}
 
     threshold_forces = 0.1
@@ -100,7 +175,7 @@ def test_threshold_stress(generate_code, generate_structure):
     """Test the ``threshold_stress`` keyword argument."""
     code = generate_code('quantum_espresso.pw')
     structure = generate_structure(symbols=('Si',))
-    generator = QuantumEspressoCommonRelaxWorkChain.get_input_generator()
+    generator = WORKCHAIN.get_input_generator()
     engines = {'relax': {'code': code, 'options': {}}}
 
     threshold_stress = 0.1
@@ -114,7 +189,7 @@ def test_magnetization_per_site(generate_code, generate_structure):
     """Test the ``magnetization_per_site`` keyword argument."""
     code = generate_code('quantum_espresso.pw')
     structure = generate_structure(symbols=('Si', 'Ge'))
-    generator = QuantumEspressoCommonRelaxWorkChain.get_input_generator()
+    generator = WORKCHAIN.get_input_generator()
     engines = {'relax': {'code': code, 'options': {}}}
 
     magnetization_per_site = [0.0, 0.1, 0.2]

--- a/tests/workflows/relax/test_siesta.py
+++ b/tests/workflows/relax/test_siesta.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.siesta` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.siesta')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('siesta').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+@pytest.mark.usefixtures('psml_family')
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('psml_family')
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+@pytest.mark.usefixtures('psml_family')
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('psml_family')
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('psml_family')
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/relax/test_vasp.py
+++ b/tests/workflows/relax/test_vasp.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.vasp` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.vasp')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'relax': {
+                'code': generate_code('vasp').store().uuid,
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.get_electronic_types():
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_relax_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``relax_types``."""
+    inputs = default_builder_inputs
+
+    for relax_type in GENERATOR.get_relax_types():
+        inputs['relax_type'] = relax_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.get_spin_types():
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)


### PR DESCRIPTION
Here we add basic unit tests for the `CommonRelaxWorkChain` for all
plugin implementations. It consists of two main parts essentially:

 * Call `InputsGenerator.get_builder`
 * Submit the builder returned by `InputsGenerator.get_builder`

The first test is performed multiple times: first with minimal required
inputs, i.e., just `structure` and `engines`. Then it is called with a
specific value for `electronic_type`, `relax_type` or `spin_type`. The
values that are passed are taken by introspecting the input generator
class itself that declares which values it supports. In this way we
check that those declarations are correct.

For the call to `get_builder` with default arguments, the returned
builder is actually submitted. This will actually force the
implementation of the `CommonRelaxWorkChain` class to be instantiated
which in turn will validate the generated builder against its input
specification. If this test passes, it means that the workchain can at
the very least be submitted and successfully created. This is no
guarantee that it would then of course successfully finish, but this
integration test is really complicated to setup in the general case, and
so is outside of the scope of these unit tests.

The difficulty in this commit is that certain input generators rely on
resources being preinstalled, for example pseudopotential families. This
is the case for Abinit, Siesta and Quantum ESPRESSO. The relevant
fixtures are added to configure those requirements that the input
generators will expect to be present.

The difficulty in this commit is that certain input generators rely on
resources being preinstalled, for example pseudopotential families. This
is the case for Abinit, Siesta and Quantum ESPRESSO. The relevant
fixtures are added to configure those requirements that the input
generators will expect to be present.