### PR TITLE
Update NWChem generator for molecular calculations

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -23,7 +23,7 @@
         "aiida-cp2k~=1.3",
         "aiida-fleur>=1.1.4",
         "aiida-gaussian",
-        "aiida-nwchem>=2.0.0",
+        "aiida-nwchem>=2.1.0",
         "aiida-orca",
         "aiida-pseudo>=0.6.0",
         "aiida-quantumespresso~=3.4,>=3.4.1",


### PR DESCRIPTION
Changes to make the protocol more robust in the case of a molecular calculation.

NWChem's plane wave code currently allows the simulation cell to be specified in two different ways. While both will be valid in the sense that a calculation will be run, using the traditional way of adding a cell will force the geometry optimisation module, "Driver", to use cartesian coordinates for the optimisation, rather than internal degrees of freedom. While this seems harmless, testing has shown that highly converged geometries are not possible as the optimisation will get stuck by making vanishingly small steps, while the forces are small but remain larger than the target tolerances.