### PR TITLE
Add an UNKNOWN ElectronicType to allow for safe smearing

### DIFF
--- a/aiida_common_workflows/common/types.py
+++ b/aiida_common_workflows/common/types.py
@@ -30,6 +30,7 @@ class SpinType(Enum):
 class ElectronicType(Enum):
     """Enumeration of known electronic types."""
 
+    UNKNOWN = 'unknown'
     AUTOMATIC = 'automatic'
     METAL = 'metal'
     INSULATOR = 'insulator'

--- a/aiida_common_workflows/workflows/relax/abinit/protocol.yml
+++ b/aiida_common_workflows/workflows/relax/abinit/protocol.yml
@@ -21,7 +21,7 @@ fast:
                 ionmov: 22 # optimize ionic positions with L-BFGS
                 dilatmx: 1.00 # don't book additional memory for basis set enlargement, Abinit default
                 # default to metallic treatment
-                occopt: 3 # Fermi-Dirac smearing
+                occopt: 7 # Gaussian smearing
                 fband: 2.00 # increase the number of bands to > fband * natoms
                 tsmear: 0.008 # Ha
                 # default to no spin treatment
@@ -52,7 +52,7 @@ moderate:
                 ionmov: 22 # optimize ionic positions with L-BFGS
                 dilatmx: 1.00 # don't book additional memory for basis set enlargement, Abinit default
                 # default to metallic treatment
-                occopt: 3 # Fermi-Dirac smearing
+                occopt: 7 # Gaussian smearing
                 fband: 2.00 # increase the number of bands to > fband * natoms
                 tsmear: 0.008 # Ha
                 # default to no spin treatment
@@ -83,7 +83,7 @@ precise:
                 ionmov: 22 # optimize ionic positions with L-BFGS
                 dilatmx: 1.00 # don't book additional memory for basis set enlargement, Abinit default
                 # default to metallic treatment
-                occopt: 3 # Fermi-Dirac smearing
+                occopt: 7 # Gaussian smearing
                 fband: 2.00 # increase the number of bands to > fband * natoms
                 tsmear: 0.005 # Ha
                 # default to no spin treatment


### PR DESCRIPTION
This is a fix for #176, as discussed in #177 .