### PR TITLE
`QuantumEspressoRelax`: apply `options` to `base_final_scf` namespace

### DIFF
--- a/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/generator.py
@@ -189,6 +189,13 @@ class QuantumEspressoCommonRelaxInputGenerator(CommonRelaxInputGenerator):
                         }
                     }
                 },
+                'base_final_scf': {
+                    'pw': {
+                        'metadata': {
+                            'options': engines['relax']['options']
+                        }
+                    }
+                },
             },
             relax_type=relax_type,
             electronic_type=electronic_type,

--- a/tests/workflows/relax/test_quantum_espresso.py
+++ b/tests/workflows/relax/test_quantum_espresso.py
@@ -51,6 +51,16 @@ def test_submit(default_builder_inputs):
 
 
 @pytest.mark.usefixtures('sssp')
+def test_options(default_builder_inputs):
+    """Test that the ``options`` of the ``engines`` argument are added to all namespaces."""
+    inputs = default_builder_inputs
+    builder = GENERATOR.get_builder(**inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+    assert builder.base.pw.metadata.options.resources == inputs['engines']['relax']['options']['resources']
+    assert builder.base_final_scf.pw.metadata.options.resources == inputs['engines']['relax']['options']['resources']
+
+
+@pytest.mark.usefixtures('sssp')
 def test_supported_electronic_types(default_builder_inputs):
     """Test calling ``get_builder`` for the supported ``electronic_types``."""
     inputs = default_builder_inputs


### PR DESCRIPTION
Fixes #219 

The `options` from the `engine` dictionary passed to the `get_builder`
was only applied to the `base` namespace, but not to `base_final_scf`
which is what a user would expect.