### PR TITLE
Feature/bands wc

### DIFF
--- a/aiida_common_workflows/common/__init__.py
+++ b/aiida_common_workflows/common/__init__.py
@@ -2,5 +2,6 @@
 # pylint: disable=redefined-builtin,undefined-variable
 """Module for resources common to the entire `aiida-common-workflows` package."""
 from .types import *
+from .structure import *
 
-all = (types.__all__,)
+all = (types.__all__, structure.__all__)

--- a/aiida_common_workflows/common/__init__.py
+++ b/aiida_common_workflows/common/__init__.py
@@ -4,4 +4,4 @@
 from .types import *
 from .structure import *
 
-all = (types.__all__, structure.__all__)
+all = (types.__all__ + structure.__all__)

--- a/aiida_common_workflows/common/structure.py
+++ b/aiida_common_workflows/common/structure.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Module collecting functions to modify StructureData objects."""
+from aiida.engine import calcfunction
 
 __all__ = ('seekpath_explicit_kp_path')
 

--- a/aiida_common_workflows/common/structure.py
+++ b/aiida_common_workflows/common/structure.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""Module collecting functions to modify StructureData objects."""
+
+__all__ = ('seekpath_explicit_kp_path')
+
+
+@calcfunction
+def seekpath_explicit_kp_path(structure, seekpath_params):
+    """
+    Return the modified structure of SeekPath and the explicit list of kpoints.
+    :param structure: StructureData containing the structure information.
+    :param seekpath_params: Dict of seekpath parameters to be unwrapped as arguments of `get_explicit_kpoints_path`.
+    """
+    from aiida.tools import get_explicit_kpoints_path
+
+    results = get_explicit_kpoints_path(structure, **seekpath_params)
+
+    return {'structure': results['primitive_structure'], 'kpoints': results['explicit_kpoints']}

--- a/aiida_common_workflows/common/structure.py
+++ b/aiida_common_workflows/common/structure.py
@@ -2,7 +2,7 @@
 """Module collecting functions to modify StructureData objects."""
 from aiida.engine import calcfunction
 
-__all__ = ('seekpath_explicit_kp_path')
+__all__ = ('seekpath_explicit_kp_path',)
 
 
 @calcfunction

--- a/aiida_common_workflows/workflows/bands/__init__.py
+++ b/aiida_common_workflows/workflows/bands/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=undefined-variable
+"""Module with the base classes for the common bands workchains."""
+from .generator import *
+
+__all__ = (generator.__all__,)

--- a/aiida_common_workflows/workflows/bands/generator.py
+++ b/aiida_common_workflows/workflows/bands/generator.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""Module with base input generator for the common bands workchains."""
+import abc
+
+from aiida import orm
+from aiida import plugins
+
+from aiida_common_workflows.common import ElectronicType, SpinType
+from aiida_common_workflows.generators import ChoiceType, InputGenerator
+
+__all__ = ('CommonBandsInputGenerator',)
+
+
+class CommonBandsInputGenerator(InputGenerator, metaclass=abc.ABCMeta):
+    """Input generator for the common bands workflow.
+
+    This class should be subclassed by implementations for specific quantum engines. After calling the super, they can
+    modify the ports defined here in the base class as well as add additional custom ports.
+    """
+
+    @classmethod
+    def define(cls, spec):
+        """Define the specification of the input generator.
+
+        The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
+        """
+        super().define(spec)
+        spec.input_namespace(
+            'seekpath_parameters',
+            help='Inputs for the seekpath to be passed to `get_explicit_kpoints_path`.',
+        )
+        spec.input(
+            'seekpath_parameters.reference_distance',
+            valid_type=float,
+            default=0.025,
+            help='Reference target distance between neighboring k-points along the path in units 1/Å.',
+        )
+        spec.input(
+            'seekpath_parameters.symprec',
+            valid_type=float,
+            default=0.00001,
+            help='The symmetry precision used internally by SPGLIB.',
+        )
+        spec.input(
+            'seekpath_parameters.angle_tolerance',
+            valid_type=float,
+            default=-1.0,
+            help='The angle tollerance used internally by SPGLIB.',
+        )
+        spec.input(
+            'seekpath_parameters.threshold',
+            valid_type=float,
+            default=0.0000001,
+            help='The treshold for determining edge cases. Meaning is different depending on bravais lattice.',
+        )
+        spec.input(
+            'seekpath_parameters.with_time_reversal',
+            valid_type=bool,
+            default=True,
+            help='If False, and the group has no inversion symmetry, additional lines are returned.',
+        )
+        spec.input(
+            'bands_kpoints',
+            valid_type=plugins.DataFactory('array.kpoints'),
+            required=False,
+            help='The full list of kpoints where to calculate bands, in (direct) coordinates of the reciprocal space.'
+        )
+        spec.input(
+            'parent_folder',
+            valid_type=orm.RemoteData,
+            required=False,
+            help='Parent folder that contains file to restart from (density matrix, wave-functions..). What is used '
+            'is plugin dependent.'
+        )
+        spec.input(
+            'structure',
+            valid_type=plugins.DataFactory('structure'),
+            help='The structure, it might be changed internally if seekpath is used.'
+        )
+        spec.input(
+            'protocol',
+            valid_type=ChoiceType(('fast', 'moderate', 'precise')),
+            default='moderate',
+            help='The protocol to use for the automated input generation. This value indicates the level of precision '
+            'of the results and computational cost that the input parameters will be selected for.',
+        )
+        spec.input(
+            'spin_type',
+            valid_type=SpinType,
+            serializer=SpinType,
+            default=SpinType.NONE,
+            help='The type of spin polarization to be used.',
+        )
+        spec.input(
+            'electronic_type',
+            valid_type=ElectronicType,
+            serializer=ElectronicType,
+            default=ElectronicType.METAL,
+            help='The electronic character of the system.',
+        )
+        spec.input(
+            'magnetization_per_site',
+            valid_type=list,
+            required=False,
+            help='The initial magnetization of the system. Should be a list of floats, where each float represents the '
+            'spin polarization in units of electrons, meaning the difference between spin up and spin down '
+            'electrons, for the site. This also corresponds to the magnetization of the site in Bohr magnetons '
+            '(μB).',
+        )
+        spec.input_namespace(
+            'engines',
+            help='Inputs for the quantum engines',
+        )
+        spec.input_namespace(
+            'engines.bands',
+            help='Inputs for the quantum engine performing the calculation of bands.',
+        )
+        spec.input(
+            'engines.bands.code',
+            valid_type=orm.Code,
+            serializer=orm.load_code,
+            help='The code instance to use for the bands calculation.',
+        )
+        spec.input(
+            'engines.bands.options',
+            valid_type=dict,
+            required=False,
+            help='Options for the bands calculations jobs.',
+        )

--- a/aiida_common_workflows/workflows/bands/siesta/__init__.py
+++ b/aiida_common_workflows/workflows/bands/siesta/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=undefined-variable
+"""Module with the implementations of the common bands workchain for Siesta."""
+from .generator import *
+from .workchain import *
+
+__all__ = (generator.__all__ + workchain.__all__)

--- a/aiida_common_workflows/workflows/bands/siesta/generator.py
+++ b/aiida_common_workflows/workflows/bands/siesta/generator.py
@@ -8,7 +8,6 @@ from aiida import engine
 from aiida import orm
 from aiida import plugins
 from aiida.common import exceptions
-from aiida.engine import calcfunction
 from aiida_common_workflows.common import ElectronicType, SpinType, seekpath_explicit_kp_path
 from aiida_common_workflows.generators import ChoiceType, CodeType
 from ..generator import CommonBandsInputGenerator

--- a/aiida_common_workflows/workflows/bands/siesta/generator.py
+++ b/aiida_common_workflows/workflows/bands/siesta/generator.py
@@ -1,0 +1,286 @@
+# -*- coding: utf-8 -*-
+"""Implementation of `aiida_common_workflows.common.bands.generator.CommonBandsInputGenerator` for SIESTA."""
+import os
+
+import yaml
+
+from aiida import engine
+from aiida import orm
+from aiida import plugins
+from aiida.common import exceptions
+from aiida.engine import calcfunction
+from aiida_common_workflows.common import ElectronicType, SpinType, seekpath_explicit_kp_path
+from aiida_common_workflows.generators import ChoiceType, CodeType
+from ..generator import CommonBandsInputGenerator
+
+__all__ = ('SiestaCommonBandsInputGenerator',)
+
+StructureData = plugins.DataFactory('structure')
+
+
+class SiestaCommonBandsInputGenerator(CommonBandsInputGenerator):
+    """Generator of inputs for the SiestaCommonBandsWorkChain"""
+
+    _default_protocol = 'moderate'
+
+    def __init__(self, *args, **kwargs):
+        """Construct an instance of the input generator, validating the class attributes."""
+
+        self._initialize_protocols()
+
+        super().__init__(*args, **kwargs)
+
+        def raise_invalid(message):
+            raise RuntimeError('invalid protocol registry `{}`: '.format(self.__class__.__name__) + message)
+
+        for k, v in self._protocols.items():  # pylint: disable=invalid-name
+
+            if 'parameters' not in v:
+                raise_invalid('protocol `{}` does not define the mandatory key `parameters`'.format(k))
+            if 'mesh-cutoff' in v['parameters']:
+                try:
+                    float(v['parameters']['mesh-cutoff'].split()[0])
+                    str(v['parameters']['mesh-cutoff'].split()[1])
+                except (ValueError, IndexError):
+                    raise_invalid(
+                        'Wrong format of `mesh-cutoff` in `parameters` of protocol '
+                        '`{}`. Value and units are required'.format(k)
+                    )
+
+            if 'basis' not in v:
+                raise_invalid('protocol `{}` does not define the mandatory key `basis`'.format(k))
+
+            if 'pseudo_family' not in v:
+                raise_invalid('protocol `{}` does not define the mandatory key `pseudo_family`'.format(k))
+
+    def _initialize_protocols(self):
+        """Initialize the protocols class attribute by parsing them from the configuration file."""
+        _filepath = os.path.join(os.path.dirname(__file__), 'protocol.yml')
+
+        with open(_filepath) as _thefile:
+            self._protocols = yaml.full_load(_thefile)
+
+    @classmethod
+    def define(cls, spec):
+        """Define the specification of the input generator.
+
+        The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
+        """
+        super().define(spec)
+        spec.inputs['spin_type'].valid_type = ChoiceType((SpinType.NONE, SpinType.COLLINEAR))
+        spec.inputs['electronic_type'].valid_type = ChoiceType((ElectronicType.METAL, ElectronicType.INSULATOR))
+        spec.inputs['engines']['bands']['code'].valid_type = CodeType('siesta.siesta')
+
+    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
+        """Construct a process builder based on the provided keyword arguments.
+
+        The keyword arguments will have been validated against the input generator specification.
+        """
+        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+        structure = kwargs['structure']
+        engines = kwargs['engines']
+        protocol = kwargs['protocol']
+        spin_type = kwargs['spin_type']
+        magnetization_per_site = kwargs.get('magnetization_per_site', None)
+        seekpath_parameters = kwargs['seekpath_parameters']
+        parent_folder = kwargs.get('parent_folder', None)
+        bands_kpoints = kwargs.get('bands_kpoints', None)
+
+        # Checks
+        if protocol not in self.get_protocol_names():
+            import warnings
+            warnings.warn('no protocol implemented with name {protocol}, using default moderate')
+            protocol = self.get_default_protocol_name()
+        if 'bands' not in engines:
+            raise ValueError('The `engines` dictionaly must contain "bands" as outermost key')
+
+        pseudo_family = self._protocols[protocol]['pseudo_family']
+        try:
+            orm.Group.objects.get(label=pseudo_family)
+        except exceptions.NotExistent as exc:
+            raise ValueError(
+                f'protocol `{protocol}` requires `pseudo_family` with name {pseudo_family} '
+                'but no family with this name is loaded in the database'
+            ) from exc
+
+        # K points for bands, possible change of structure due to SeeK-Path
+        if bands_kpoints is None:
+            res = seekpath_explicit_kp_path(structure, orm.Dict(dict=seekpath_parameters))
+            structure = res['structure']
+            bandskpoints = res['kpoints']
+            if parent_folder is not None:
+                raise ValueError(
+                    'A parent folder has been passed to trigger a restart, but SeeK-Path modified the '
+                    'structure and the old DM is unusable. Define `bands_kpoints` explicitly '
+                    'in order to not trigger SeeK-Path or remove the `parent_folder`.'
+                )
+        else:
+            bandskpoints = bands_kpoints
+
+        # K points
+        kpoints_mesh = self._get_kpoints(protocol, structure)
+
+        # Parameters, including scf ...
+        parameters = self._get_param(protocol, structure)
+        #... spin options (including initial magentization) ...
+        if spin_type == SpinType.COLLINEAR:
+            parameters['spin'] = 'polarized'
+        if magnetization_per_site is not None:
+            if spin_type == SpinType.NONE:
+                import warnings
+                warnings.warn('`magnetization_per_site` will be ignored as `spin_type` is set to SpinType.NONE')
+            if spin_type == SpinType.COLLINEAR:
+                in_spin_card = '\n'
+                for i, magn in enumerate(magnetization_per_site):
+                    in_spin_card += f' {i+1} {magn} \n'
+                in_spin_card += '%endblock dm-init-spin'
+                parameters['%block dm-init-spin'] = in_spin_card
+
+        # Basis
+        basis = self._get_basis(protocol, structure)
+
+        # Pseudo fam
+        pseudo_family = self._get_pseudo_fam(protocol)
+
+        builder = self.process_class.get_builder()
+        builder.structure = structure
+        builder.basis = orm.Dict(dict=basis)
+        builder.parameters = orm.Dict(dict=parameters)
+        if kpoints_mesh:
+            builder.kpoints = kpoints_mesh
+        builder.pseudo_family = pseudo_family
+        builder.options = orm.Dict(dict=engines['bands']['options'])
+        builder.code = orm.load_code(engines['bands']['code'])
+        builder.bandskpoints = bandskpoints
+        if parent_folder is not None:
+            builder.parent_calc_folder = parent_folder
+            #Maybe impose just one scf step if this happens??????
+
+        return builder
+
+    def _get_param(self, key, structure):  # pylint: disable=too-many-branches,too-many-locals
+        """
+        Method to construct the `parameters` input. Heuristics are applied, a dictionary
+        with the parameters is returned.
+        """
+        parameters = self._protocols[key]['parameters'].copy()
+
+        if 'atomic_heuristics' in self._protocols[key]:  # pylint: disable=too-many-nested-blocks
+            atomic_heuristics = self._protocols[key]['atomic_heuristics']
+
+            if 'mesh-cutoff' in parameters:
+                meshcut_glob = parameters['mesh-cutoff'].split()[0]
+                meshcut_units = parameters['mesh-cutoff'].split()[1]
+            else:
+                meshcut_glob = None
+
+            # Run through heuristics
+            for kind in structure.kinds:
+                need_to_apply = False
+                try:
+                    cust_param = atomic_heuristics[kind.symbol]['parameters']
+                    need_to_apply = True
+                except KeyError:
+                    pass
+                if need_to_apply:
+                    if 'mesh-cutoff' in cust_param:
+                        try:
+                            cust_meshcut = float(cust_param['mesh-cutoff'].split()[0])
+                        except (ValueError, IndexError) as exc:
+                            raise RuntimeError(
+                                'Wrong `mesh-cutoff` value for heuristc '
+                                '{0} of protocol {1}'.format(kind.symbol, key)
+                            ) from exc
+                        if meshcut_glob is not None:
+                            if cust_meshcut > float(meshcut_glob):
+                                meshcut_glob = cust_meshcut
+                        else:
+                            meshcut_glob = cust_meshcut
+                            try:
+                                meshcut_units = cust_param['mesh-cutoff'].split()[1]
+                            except (ValueError, IndexError) as exc:
+                                raise RuntimeError(
+                                    'Wrong `mesh-cutoff` units for heuristc '
+                                    '{0} of protocol {1}'.format(kind.symbol, key)
+                                ) from exc
+
+            if meshcut_glob is not None:
+                parameters['mesh-cutoff'] = '{0} {1}'.format(meshcut_glob, meshcut_units)
+
+        return parameters
+
+    def _get_basis(self, key, structure):  #pylint: disable=too-many-branches
+        """
+        Method to construct the `basis` input.
+        Heuristics are applied, a dictionary with the basis is returned.
+        """
+        basis = self._protocols[key]['basis'].copy()
+
+        if 'atomic_heuristics' in self._protocols[key]:  # pylint: disable=too-many-nested-blocks
+            atomic_heuristics = self._protocols[key]['atomic_heuristics']
+
+            pol_dict = {}
+            size_dict = {}
+            pao_block_dict = {}
+
+            # Run through all the heuristics
+            for kind in structure.kinds:
+                need_to_apply = False
+                try:
+                    cust_basis = atomic_heuristics[kind.symbol]['basis']
+                    need_to_apply = True
+                except KeyError:
+                    pass
+                if need_to_apply:
+                    if 'split-tail-norm' in cust_basis:
+                        basis['pao-split-tail-norm'] = True
+                    if 'polarization' in cust_basis:
+                        pol_dict[kind.name] = cust_basis['polarization']
+                    if 'size' in cust_basis:
+                        size_dict[kind.name] = cust_basis['size']
+                    if 'pao-block' in cust_basis:
+                        pao_block_dict[kind.name] = cust_basis['pao-block']
+                        if kind.name != kind.symbol:
+                            pao_block_dict[kind.name] = pao_block_dict[kind.name].replace(kind.symbol, kind.name)
+
+            if pol_dict:
+                card = '\n'
+                for k, value in pol_dict.items():
+                    card = card + f'  {k}  {value} \n'
+                card = card + '%endblock paopolarizationscheme'
+                basis['%block pao-polarization-scheme'] = card
+            if size_dict:
+                card = '\n'
+                for k, value in size_dict.items():
+                    card = card + f'  {k}  {value} \n'
+                card = card + '%endblock paobasissizes'
+                basis['%block pao-basis-sizes'] = card
+            if pao_block_dict:
+                card = '\n'
+                for k, value in pao_block_dict.items():
+                    card = card + f'{value} \n'
+                card = card + '%endblock pao-basis'
+                basis['%block pao-basis'] = card
+
+        return basis
+
+    def _get_kpoints(self, key, structure):
+        """
+        Method to construct the kpoints mesh
+        """
+        from aiida.orm import KpointsData
+        if 'kpoints' in self._protocols[key]:
+            kpoints_mesh = KpointsData()
+            kpoints_mesh.set_cell_from_structure(structure)
+            kp_dict = self._protocols[key]['kpoints']
+            if 'offset' in kp_dict:
+                kpoints_mesh.set_kpoints_mesh_from_density(distance=kp_dict['distance'], offset=kp_dict['offset'])
+            else:
+                kpoints_mesh.set_kpoints_mesh_from_density(distance=kp_dict['distance'])
+            return kpoints_mesh
+
+        return None
+
+    def _get_pseudo_fam(self, key):
+        from aiida.orm import Str
+        return Str(self._protocols[key]['pseudo_family'])

--- a/aiida_common_workflows/workflows/bands/siesta/protocol.yml
+++ b/aiida_common_workflows/workflows/bands/siesta/protocol.yml
@@ -1,0 +1,282 @@
+moderate:
+  description: 'A standard list of inputs for Siesta. Tested with DeltaTest. No Spin-Orbit support.'
+  parameters:
+    xc-functional: "GGA"
+    xc-authors: "PBE"
+    max-scf-iterations: 50
+    scf-mixer-history: 5
+    scf-mixer-weight: 0.1
+    scf-dm-tolerance: 1.e-4  #1.e-5
+    solution-method: 'diagon'
+    electronic-temperature: '25 meV'
+    write-forces: True
+    mesh-cutoff: '200 Ry'
+    write-mulliken-pop: 1
+  basis:
+    pao-energy-shift: '50 meV'
+    pao-basis-size: 'DZP'
+  pseudo_family: 'nc-sr-04_pbe_standard_psml'
+  kpoints:
+    distance: 0.1
+    offset: [0., 0., 0.]
+  atomic_heuristics:
+    Li:
+      parameters:
+        mesh-cutoff: '250 Ry'
+      basis:
+        polarization: 'non-perturbative'
+    Be:
+      parameters:
+        mesh-cutoff: '250 Ry'
+      basis:
+        polarization: 'non-perturbative'
+    Na:
+      parameters:
+        mesh-cutoff: '250 Ry'
+      basis:
+        polarization: 'non-perturbative'
+    Mg:
+      parameters:
+        mesh-cutoff: '250 Ry'
+      basis:
+        polarization: 'non-perturbative'
+    Mn:
+      parameters:
+        mesh-cutoff: '400 Ry'
+    Fe:
+      parameters:
+        mesh-cutoff: '400 Ry'
+    Ag:
+      parameters:
+        mesh-cutoff: '300 Ry'
+    Ca:
+      basis:
+        pao-block: "Ca 3 \n  n=3   0   1 \n  3.505 \n n=4   0   2  \n 7.028      0.000 \n n=3   1   1 \n 4.072"
+        split-tail-norm: True
+    Sr:
+      basis:
+        pao-block: "Sr 3 \n  n=4   0   1 \n  3.809 \n n=5   0   2  \n  7.599      0.000  \n n=4   1   1 \n 4.538"
+        split-tail-norm: True
+    Ba:
+      basis:
+        pao-block: "Ba 3 \n  n=5   0   1 \n  4.369 \n n=6   0   2  \n 7.602      0.000 \n n=5   1   1 \n 5.205"
+        split-tail-norm: True
+    Sb:
+      parameters:
+        mesh-cutoff: '400 Ry'
+    Hg:
+      basis:
+        pao-block: "Hg 4 \n  n=5   0   1 \n  3.568 \n n=6   0   2  \n 6.573  0.0 \n n=5   1   2 \n 4.059  0.0 \n n=5   2  1 \n 5.918"
+
+precise:
+  description: 'A more stringent set of siesta parameters. Never tested.'
+  parameters:
+    xc-functional: "GGA"
+    xc-authors: "PBE"
+    max-scf-iterations: 100
+    scf-mixer-history: 5
+    scf-mixer-weight: 0.1
+    scf-dm-tolerance: 1.e-5
+    md-max-force-tol: '0.005 eV/Ang'
+    md-max-stress-tol: '0.7 GPa'
+    solution-method: 'diagon'
+    electronic-temperature: '25 meV'
+    write-forces: True
+    mesh-cutoff: '500 Ry'
+  basis:
+    pao-energy-shift: '50 meV'
+    pao-basis-size: 'DZP'
+  pseudo_family: 'nc-sr-04_pbe_standard_psml'
+  kpoints:
+    distance: 0.1 #0.062
+    offset: [0., 0., 0.]
+  atomic_heuristics:
+    H:
+      basis:
+        pao-block: "H 1\n  n=1  0  2  P 1 \n 6.0473 \t 2.5529"
+    Li:
+      basis:
+        size: 'DZDP'
+        polarization: 'non-perturbative'
+    Be:
+      basis:
+        polarization: 'non-perturbative'
+    B:
+      basis:
+        pao-block: "B 2\n  n=2  0  2 \n 5.9924789\t 2.0\n  n=2  1  2  P 2 \n 7.50444\t 2.9"
+    C:
+      basis:
+        pao-block: "C 2\n  n=2  0  2 \n 4.99376\t 2.00\n  n=2  1  2  P 2 \n 6.2538\t 2.715"
+    N:
+      basis:
+        pao-block: "N 2\n  n=2  0  3 \n 4.389\t 2.1270\t 3.2669\n  n=2  1  3  P 1 \n 5.496\t 2.0914\t 3.522"
+    Na:
+      basis:
+        polarization: 'non-perturbative'
+    Mg:
+      basis:
+        pao-block: "Mg 4\n  n=2  0  1 \n 2.56\n  n=2  1  1 \n 2.9\n  n=3  0  2 \n 8.0855\t 6.8564\n  n=3  1  2 \n 8.0855\t 7.50"
+    Al:
+      basis:
+        pao-block: "Al 3\n  n=3  0  2 \n 6.924\t 5.326 \n  n=3  1  2\n 9.116\t 6.505 \n  n=3  2  2\n 7.20\t 3.7"
+    Si:
+      basis:
+        pao-block: "Si 3\n  n=3  0  2 \n 6.571\t 4.3497\n  n=3  1  2\n 8.239\t 5.117\n  n=3  2  2\n 7.20\t 3.7"
+    P:
+      basis:
+        pao-block: "P 3\n  n=3  0  2 \n 5.43\t 2.5\n  n=3  1  2 \n 6.97\t 3.65\n  n=3  2  2 \n 6.97\t 3.63"
+    S:
+      basis:
+        pao-block: "S 3\n  n=3  0  2 \n 4.96485\t 2.51\n  n=3  1  2 \n 6.2177\t 2.51\n  n=3  2  2 \n 6.2177\t 3.6149"
+    Cl:
+      basis:
+        size: 'DZDP'
+    K:
+      basis:
+        size: 'TZP'
+    Ca:
+      basis:
+        pao-block: "Ca 3 \n  n=3   0   1 \n  3.505 \n n=4   0   2  \n 7.028      0.000 \n n=3   1   1 \n 4.072"
+        split-tail-norm: True
+    Sc:
+      basis:
+        pao-block: "Sc 4\n  n=3  0  1 \n 4.24658\n  n=3  1  1 \n 4.466\n  n=3  2  2 \n 6.8927\t 4.0\n  n=4  0  2  P 1 \n 9.0744\t 4.14"
+    Ti:
+      basis:
+        pao-block: "Ti 4\n  n=3  0  1 \n 3.4329\n  n=3  1  1 \n 4.318\n  n=3  2  2 \n 6.1\t 4.4425\n  n=4  0  2  P 1\n 8.662\t 3.389"
+    V:
+      basis:
+        pao-block: "V 4\n  n=3  0  1 \n 3.75\n  n=3  1  1 \n  3.9946\n  n=3  2  2 \n 5.6945\t 3.88\n  n=4  0  2  P 1 \n 8.28546\t 3.17"
+      parameters:
+        mesh-cutoff: '850 Ry'
+    Cr:
+      basis:
+        size: 'TZP'
+    Mn:
+      parameters:
+        mesh-cutoff: '850 Ry'
+      basis:
+        size: 'TZP'
+    Fe:
+      basis:
+        size: 'TZP'
+    Ni:
+      parameters:
+        mesh-cutoff: '850 Ry'
+      basis:
+        size: 'TZP'
+    Cu:
+      basis:
+        size: 'TZP'
+    Zn:
+      basis:
+        size: 'TZP'
+    Ga:
+      basis:
+        size: 'DZDP'
+    Ge:
+      basis:
+        pao-block: "Ge 3\n  n=4  0  2 \n 5.323265\t 0.0\n  n=4  1  2  P 2 \n 6.06078\t 0.0\n  n=3  2  1 \n 4.224"
+    As:
+      basis:
+        size: 'TZP'
+    Se:
+      basis:
+        size: 'DZDP'
+    Br:
+      basis:
+        size: 'TZP'
+    Rb:
+      basis:
+        size: 'TZP'
+    Sr:
+      basis:
+        pao-block: "Sr 3 \n  n=4   0   1 \n  3.809 \n n=5   0   2  \n  7.599      0.000  \n n=4   1   1 \n 4.538"
+        split-tail-norm: True
+    Zr:
+      basis:
+        size: 'TZP'
+    Nb:
+      basis:
+        size: 'TZP'
+    Mo:
+      basis:
+        size: 'TZP'
+    Tc:
+      basis:
+        size: 'TZP'
+    Ru:
+      basis:
+        size: 'TZP'
+    Rh:
+      basis:
+        size: 'TZP'
+    Pd:
+      basis:
+        size: 'TZP'
+    Ag:
+      parameters:
+        mesh-cutoff: '850 Ry'
+      basis:
+        size: 'DZDP'
+    Cd:
+      basis:
+        size: 'TZP'
+    Sb:
+      basis:
+        size: 'DZDP'
+    Te:
+      basis:
+        pao-block: "Te 3\n  n=5  0  3 \n 5.3203\t 3.300\t 3.500\n  n=5  1  3  P 1 \n 6.0497\t 3.3865\t 4.3158\n  n=4  2  1 \n 4.5104"
+    I:
+      basis:
+        size: 'TZP'
+    Cs:
+      basis:
+        size: 'TZP'
+    Ba:
+      basis:
+        pao-block: "Ba 3 \n  n=5   0   1 \n  4.369 \n n=6   0   2  \n 7.602      0.000 \n n=5   1   1 \n 5.205"
+        split-tail-norm: True
+    Ta:
+      basis:
+        size: 'TZP'
+    Ir:
+      basis:
+        size: 'TZP'
+    Pt:
+      basis:
+        size: 'TZP'
+    Au:
+      basis:
+        size: 'DZDP'
+    Hg:
+      basis:
+        pao-block: "Hg 4 \n  n=5   0   1 \n  3.568 \n n=6   0   2  \n 6.573  0.0 \n n=5   1   1 \n 4.059  0.0 \n n=5   2  2 \n 5.918"
+    Pb:
+      basis:
+        size: 'TZP'
+    Po:
+      basis:
+        size: 'TZP'
+
+fast:
+  description: 'A list of inputs for Siesta for quick exploratory calculations. Never tested! No Spin-Orbit.'
+  parameters:
+    xc-functional: "GGA"
+    xc-authors: "PBE"
+    max-scf-iterations: 50
+    scf-mixer-history: 5
+    scf-mixer-weight: 0.1
+    scf-dm-tolerance: 1.e-3
+    solution-method: 'diagon'
+    electronic-temperature: '25 meV'
+    write-forces: True
+    mesh-cutoff: '50 Ry'
+  basis:
+    pao-energy-shift: '200 meV'
+    pao-basis-size: 'DZ'
+  pseudo_family: 'nc-sr-04_pbe_standard_psml'
+  kpoints:
+    distance: 0.2
+    offset: [0., 0., 0.]

--- a/aiida_common_workflows/workflows/bands/siesta/workchain.py
+++ b/aiida_common_workflows/workflows/bands/siesta/workchain.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for SIESTA."""
-from aiida import orm
-from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
 
 from ..workchain import CommonBandsWorkChain

--- a/aiida_common_workflows/workflows/bands/siesta/workchain.py
+++ b/aiida_common_workflows/workflows/bands/siesta/workchain.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for SIESTA."""
+from aiida import orm
+from aiida.engine import calcfunction
+from aiida.plugins import WorkflowFactory
+
+from ..workchain import CommonBandsWorkChain
+from .generator import SiestaCommonBandsInputGenerator
+
+__all__ = ('SiestaCommonBandsWorkChain',)
+
+
+class SiestaCommonBandsWorkChain(CommonBandsWorkChain):
+    """Implementation of `aiida_common_workflows.common.bands.workchain.CommonBandsWorkChain` for SIESTA."""
+
+    _process_class = WorkflowFactory('siesta.base')
+    _generator_class = SiestaCommonBandsInputGenerator
+
+    def convert_outputs(self):
+        """Convert the outputs of the sub workchain to the common output specification."""
+        self.report('Bands calculation concluded sucessfully, converting outputs')
+        if 'bands' not in self.ctx.workchain.outputs:
+            self.report('SiestaBaseWorkChain concluded without returning bands!')
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED
+        self.out('bands', self.ctx.workchain.outputs['bands'])

--- a/aiida_common_workflows/workflows/bands/workchain.py
+++ b/aiida_common_workflows/workflows/bands/workchain.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Module with base wrapper workchain for bands workchains."""
+from abc import ABCMeta, abstractmethod
+
+from aiida.engine import WorkChain, ToContext
+from aiida.orm import BandsData
+
+from .generator import CommonBandsInputGenerator
+
+__all__ = ('CommonBandsWorkChain',)
+
+
+class CommonBandsWorkChain(WorkChain, metaclass=ABCMeta):
+    """Base workchain implementation that serves as a wrapper for bands workchains.
+
+    Subclasses should simply define the concrete plugin-specific bands workchain for the `_process_class` attribute
+    and implement the `convert_outputs` class method to map the plugin specific outputs to the output spec of this
+    common wrapper workchain.
+    """
+
+    _process_class = None
+    _generator_class = None
+
+    @classmethod
+    def get_input_generator(cls) -> CommonBandsInputGenerator:
+        """Return an instance of the input generator for this work chain.
+
+        :return: input generator
+        """
+        return cls._generator_class(process_class=cls)  # pylint: disable=not-callable
+
+    @classmethod
+    def define(cls, spec):
+        # yapf: disable
+        super().define(spec)
+        spec.expose_inputs(cls._process_class)
+        spec.outline(
+            cls.run_workchain,
+            cls.inspect_workchain,
+            cls.convert_outputs,
+        )
+        spec.output('bands', valid_type=BandsData, required=False,
+            help='All cell dimensions and atomic positions are in Ångstrom.')
+        spec.exit_code(400, 'ERROR_SUB_PROCESS_FAILED',
+            message='The `{cls}` workchain failed with exit status {exit_status}.')
+
+    def run_workchain(self):
+        """Run the wrapped workchain."""
+        inputs = self.exposed_inputs(self._process_class)
+        return ToContext(workchain=self.submit(self._process_class, **inputs))
+
+    def inspect_workchain(self):
+        """Inspect the terminated workchain."""
+        if not self.ctx.workchain.is_finished_ok:
+            cls = self._process_class.__name__
+            exit_status = self.ctx.workchain.exit_status
+            self.report('the `{}` failed with exit status {}'.format(cls, exit_status))
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=cls, exit_status=exit_status)
+
+    @abstractmethod
+    def convert_outputs(self):
+        """Convert the outputs of the sub workchain to the common output specification."""

--- a/setup.json
+++ b/setup.json
@@ -71,7 +71,8 @@
             "common_workflows.relax.orca = aiida_common_workflows.workflows.relax.orca.workchain:OrcaCommonRelaxWorkChain",
             "common_workflows.relax.quantum_espresso = aiida_common_workflows.workflows.relax.quantum_espresso.workchain:QuantumEspressoCommonRelaxWorkChain",
             "common_workflows.relax.siesta = aiida_common_workflows.workflows.relax.siesta.workchain:SiestaCommonRelaxWorkChain",
-            "common_workflows.relax.vasp = aiida_common_workflows.workflows.relax.vasp.workchain:VaspCommonRelaxWorkChain"
+            "common_workflows.relax.vasp = aiida_common_workflows.workflows.relax.vasp.workchain:VaspCommonRelaxWorkChain",
+            "common_workflows.bands.siesta = aiida_common_workflows.workflows.bands.siesta.workchain:SiestaCommonBandsWorkChain"
         ]
     },
     "license": "MIT License",

--- a/tests/workflows/bands/test_implementations.py
+++ b/tests/workflows/bands/test_implementations.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import orm
+from aiida import plugins
+
+from aiida_common_workflows.common.types import ElectronicType, SpinType
+from aiida_common_workflows.generators.ports import InputGeneratorPort
+from aiida_common_workflows.plugins import get_workflow_entry_point_names
+from aiida_common_workflows.workflows.bands.workchain import CommonBandsWorkChain
+
+
+@pytest.fixture(scope='function', params=get_workflow_entry_point_names('bands'))
+def workchain(request) -> CommonBandsWorkChain:
+    """Fixture that parametrizes over all the registered implementations of the ``CommonBandsWorkChain``."""
+    return plugins.WorkflowFactory(request.param)
+
+
+def test_spec(workchain):
+    """Test that the input specification of all implementations respects the common interface."""
+    generator = workchain.get_input_generator()
+    generator_spec = generator.spec()
+
+    required_ports = {
+        'structure': {
+            'valid_type': plugins.DataFactory('structure')
+        },
+        'bands_kpoints': {
+            'valid_type': plugins.DataFactory('array.kpoints')
+        },
+        'parent_folder': {
+            'valid_type': orm.RemoteData
+        },
+        'protocol': {
+            'valid_type': str
+        },
+        'spin_type': {
+            'valid_type': SpinType
+        },
+        'electronic_type': {
+            'valid_type': ElectronicType
+        },
+        'magnetization_per_site': {
+            'valid_type': list
+        },
+        'engines': {},
+        'seekpath_parameters': {}
+    }
+
+    for port_name, values in required_ports.items():
+        assert isinstance(generator_spec.inputs.get_port(port_name), (InputGeneratorPort, engine.PortNamespace))
+
+        if 'valid_type' in values:
+            assert generator_spec.inputs.get_port(port_name).valid_type is values['valid_type']

--- a/tests/workflows/bands/test_siesta.py
+++ b/tests/workflows/bands/test_siesta.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.siesta` module."""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from aiida import engine
+from aiida import plugins
+
+WORKCHAIN = plugins.WorkflowFactory('common_workflows.bands.siesta')
+GENERATOR = WORKCHAIN.get_input_generator()
+
+
+@pytest.fixture
+def default_builder_inputs(generate_code, generate_structure):
+    """Return a dictionary with minimum required inputs for the ``get_builder`` method of the inputs generator."""
+    return {
+        'structure': generate_structure(symbols=('Si',)),
+        'engines': {
+            'bands': {
+                'code': generate_code('siesta.siesta').store().uuid,
+                'options': {
+                    'max_wallclock_seconds': 3600,
+                    'resources': {
+                        'num_machines': 1,
+                        'tot_num_mpiprocs': 1
+                    }
+                }
+            }
+        },
+    }
+
+
+@pytest.mark.usefixtures('psml_family')
+def test_get_builder(default_builder_inputs):
+    """Test the ``get_builder`` with default arguments."""
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('psml_family')
+@pytest.mark.skip('Running this test will fail with an `UnroutableError` in `kiwipy`.')
+def test_submit(default_builder_inputs):
+    """Test submitting the builder returned by ``get_builder`` called with default arguments.
+
+    This will actually create the ``WorkChain`` instance, so if it doesn't raise, that means the input spec was valid.
+    """
+    builder = GENERATOR.get_builder(**default_builder_inputs)
+    engine.submit(builder)
+
+
+@pytest.mark.usefixtures('psml_family')
+def test_supported_electronic_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``electronic_types``."""
+    inputs = default_builder_inputs
+
+    for electronic_type in GENERATOR.spec().inputs['electronic_type'].choices:
+        inputs['electronic_type'] = electronic_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)
+
+
+@pytest.mark.usefixtures('psml_family')
+def test_supported_spin_types(default_builder_inputs):
+    """Test calling ``get_builder`` for the supported ``spin_types``."""
+    inputs = default_builder_inputs
+
+    for spin_type in GENERATOR.spec().inputs['spin_type'].choices:
+        inputs['spin_type'] = spin_type
+        builder = GENERATOR.get_builder(**inputs)
+        assert isinstance(builder, engine.ProcessBuilder)

--- a/tests/workflows/bands/test_workchain.py
+++ b/tests/workflows/bands/test_workchain.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=abstract-method,arguments-differ,redefined-outer-name
+"""Tests for the :mod:`aiida_common_workflows.workflows.bands.workchain` module."""
+import pytest
+
+from aiida.plugins import WorkflowFactory
+
+from aiida_common_workflows.plugins import get_workflow_entry_point_names
+from aiida_common_workflows.workflows.bands import CommonBandsInputGenerator
+from aiida_common_workflows.workflows.bands.workchain import CommonBandsWorkChain
+
+
+@pytest.fixture(scope='function', params=get_workflow_entry_point_names('bands'))
+def workchain(request) -> CommonBandsWorkChain:
+    """Fixture that parametrizes over all the registered implementations of the ``CommonBandsWorkChain``."""
+    return WorkflowFactory(request.param)
+
+
+def test_workchain_class(workchain):
+    """Test that each registered common bands workchain can be imported and subclasses ``CommonBandsWorkChain``."""
+    assert issubclass(workchain, CommonBandsWorkChain)
+
+
+def test_get_input_generator(workchain):
+    """Test that each registered common bands workchain defines the associated input generator."""
+    generator = workchain.get_input_generator()
+    assert isinstance(generator, CommonBandsInputGenerator)
+    assert issubclass(generator.process_class, CommonBandsWorkChain)


### PR DESCRIPTION
Implements the abstract classes for the common workflow calculating the band structure, as discussed in #222 

Some design choices that can be debated:
1) We agreed on the fact that two possibilities are foreseen: the user specifies a full list of kpoints in input or it uses `seekpath`. In the implementation, the use of seekpath is default, unless the input “bands_kpoints” is specified. Should we maybe make more explicit this choice? How?
2) We did not agree on the output energy units. I guess eV. We should also sort the issue of fermi energy in BandsData (https://github.com/aiidateam/aiida-core/issues/5032) or return the fermi energy as direct output.
3) The way to pass wavefunction or DM is based on the idea to pass a `RemoteData` folder. Will this concept be present in aiida 2.0?
4) Some repetition of code is now seen between the code-specific implementation of `RelaxInputGenerator` and `BandsInputGenerator`. Moreover the protocol list (yaml file) is duplicated. Any better way to do that?

Also the siesta implementation is provided as a reference for other codes.