### PR TITLE
`EquationOfStateWorkChain`: fix `reference_workchain` use

### DIFF
--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -140,9 +140,12 @@ class EquationOfStateWorkChain(WorkChain):
         structure = scale_structure(self.inputs.structure, scale_factor)
         process_class = WorkflowFactory(self.inputs.sub_process_class)
 
+        base_inputs = {'structure': structure}
+        if reference_workchain is not None:
+            base_inputs['reference_workchain'] = reference_workchain
+
         builder = process_class.get_input_generator().get_builder(
-            structure=structure,
-            reference_workchain=reference_workchain,
+            **base_inputs,
             **self.inputs.generator_inputs
         )
         builder._update(**self.inputs.get('sub_process', {}))  # pylint: disable=protected-access


### PR DESCRIPTION
Fixes #244 

In the current implementation, the `reference_workchain` is always
passed to the `get_builder()` method of the input generator in the
`get_sub_workchain_builder()` method. However, in case the
`reference_workchain` is `None`, this leads to an error with
the new input generator specification based on the spec/ports.

Here we change the `get_sub_workchain_builder()` method to only pass the
`reference_workchain` to the `get_builder()` method in case it is not
`None`.