### PR TITLE
Introduce the serialization of inputs of `get_builder`

### DIFF
--- a/aiida_common_workflows/generators/generator.py
+++ b/aiida_common_workflows/generators/generator.py
@@ -87,7 +87,7 @@ class InputGenerator(ProtocolRegistry, metaclass=abc.ABCMeta):
         if validation_error is not None:
             raise ValueError(validation_error)
 
-        return self._construct_builder(**processed_kwargs)
+        return self._construct_builder(**serialized_kwargs)
 
     @abc.abstractmethod
     def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:

--- a/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -323,13 +323,6 @@ def generate_inputs(
 
     type_check(structure, orm.StructureData)
 
-    if not isinstance(code, orm.Code):
-        try:
-            code = orm.load_code(code)
-        except (exceptions.MultipleObjectsError, exceptions.NotExistent) as exception:
-            msg = f'could not load the code {code}'
-            raise ValueError(msg) from exception
-
     if process_class == AbinitCalculation:
         protocol = protocol['abinit']
         dictionary = generate_inputs_calculation(protocol, code, structure, override)

--- a/aiida_common_workflows/workflows/relax/bigdft/generator.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/generator.py
@@ -256,7 +256,7 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             psprel = [os.path.normpath(os.path.relpath(i)) for i in psp]
             builder.pseudos.extend(psprel)
         builder.parameters = BigDFTParameters(dict=inputdict)
-        builder.code = orm.load_code(engines[relaxation_schema]['code'])
+        builder.code = engines[relaxation_schema]['code']
         run_opts = {'options': engines[relaxation_schema]['options']}
         builder.run_opts = orm.Dict(dict=run_opts)
 

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -260,12 +260,6 @@ def generate_inputs(
 
     type_check(structure, orm.StructureData)
 
-    if not isinstance(code, orm.Code):
-        try:
-            code = orm.load_code(code)
-        except (exceptions.MultipleObjectsError, exceptions.NotExistent) as exception:
-            raise ValueError('could not load the code {}: {}'.format(code, exception)) from exception
-
     if process_class == CastepCalculation:
         protocol = protocol['relax']['base']['calc']
         dictionary = generate_inputs_calculation(protocol, code, structure, otfg_family, override)

--- a/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -270,7 +270,7 @@ class Cp2kCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         )
 
         # CP2K code.
-        builder.cp2k.code = orm.load_code(engines['relax']['code'])
+        builder.cp2k.code = engines['relax']['code']
 
         # Run options.
         builder.cp2k.metadata.options = engines['relax']['options']

--- a/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -78,10 +78,6 @@ class FleurCommonRelaxInputGenerator(CommonRelaxInputGenerator):
 
         inpgen_code = engines['inpgen']['code']
         fleur_code = engines['relax']['code']
-        if not isinstance(inpgen_code, orm.Code):
-            inpgen_code = orm.load_code(inpgen_code)
-        if not isinstance(fleur_code, orm.Code):
-            fleur_code = orm.load_code(fleur_code)
         options = engines['relax'].get('options', {})
         options_scf = orm.Dict(dict=options)
         # Checks if protocol exists

--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -7,8 +7,6 @@ from aiida import engine
 from aiida import orm
 from aiida import plugins
 
-from aiida.orm import load_code
-
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators import ChoiceType, CodeType
 from ..generator import CommonRelaxInputGenerator
@@ -109,7 +107,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             if 'num_mpiprocs_per_machine' in res:
                 n_proc = res['num_machines'] * res['num_mpiprocs_per_machine']
             else:
-                code = load_code(engines['relax']['code'])
+                code = engines['relax']['code']
                 def_mppm = code.computer.get_default_mpiprocs_per_machine()
                 if def_mppm is not None:
                     n_proc = res['num_machines'] * def_mppm
@@ -189,7 +187,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         builder = self.process_class.get_builder()
         builder.gaussian.structure = structure
         builder.gaussian.parameters = orm.Dict(dict=params)
-        builder.gaussian.code = orm.load_code(engines['relax']['code'])
+        builder.gaussian.code = engines['relax']['code']
         builder.gaussian.metadata.options = engines['relax']['options']
 
         return builder

--- a/aiida_common_workflows/workflows/relax/nwchem/generator.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/generator.py
@@ -160,7 +160,7 @@ class NwchemCommonRelaxInputGenerator(CommonRelaxInputGenerator):
 
         # Prepare builder
         builder = self.process_class.get_builder()
-        builder.nwchem.code = orm.load_code(engines['relax']['code'])
+        builder.nwchem.code = engines['relax']['code']
         builder.nwchem.metadata.options = engines['relax']['options']
         builder.nwchem.structure = structure
         builder.nwchem.add_cell = add_cell

--- a/aiida_common_workflows/workflows/relax/orca/generator.py
+++ b/aiida_common_workflows/workflows/relax/orca/generator.py
@@ -140,7 +140,7 @@ class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             if 'num_mpiprocs_per_machine' in resources:
                 nproc = resources['num_machines'] * resources['num_mpiprocs_per_machine']
             else:
-                code = orm.load_code(engines['relax']['code'])
+                code = engines['relax']['code']
                 default_mpiprocs = code.computer.get_default_mpiprocs_per_machine()
                 if default_mpiprocs is not None:
                     nproc = resources['num_machines'] * default_mpiprocs
@@ -151,7 +151,7 @@ class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         builder = self.process_class.get_builder()
         builder.orca.structure = structure
         builder.orca.parameters = orm.Dict(dict=params)
-        builder.orca.code = orm.load_code(engines['relax']['code'])
+        builder.orca.code = engines['relax']['code']
         builder.orca.metadata.options = engines['relax']['options']
         return builder
 

--- a/aiida_common_workflows/workflows/relax/siesta/generator.py
+++ b/aiida_common_workflows/workflows/relax/siesta/generator.py
@@ -153,7 +153,7 @@ class SiestaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             builder.kpoints = kpoints_mesh
         builder.pseudo_family = pseudo_family
         builder.options = orm.Dict(dict=engines['relax']['options'])
-        builder.code = orm.load_code(engines['relax']['code'])
+        builder.code = engines['relax']['code']
 
         return builder
 

--- a/aiida_common_workflows/workflows/relax/vasp/generator.py
+++ b/aiida_common_workflows/workflows/relax/vasp/generator.py
@@ -5,7 +5,6 @@ import pathlib
 import yaml
 
 from aiida import engine
-from aiida import orm
 from aiida import plugins
 from aiida.common.extendeddicts import AttributeDict
 
@@ -76,7 +75,7 @@ class VaspCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         builder = self.process_class.get_builder()
 
         # Set code
-        builder.code = orm.load_code(engines['relax']['code'])
+        builder.code = engines['relax']['code']
 
         # Set structure
         builder.structure = structure


### PR DESCRIPTION
Fixes #40

This was forgotten in the implementation due to a typo.
Some plugins generators has been changed to take into account
that the passed value for the code is now always a orm.Code
instance.
