### PR TITLE
`InputGenerator`: ensure the `_spec` attribute is subclass specific

### DIFF
--- a/aiida_common_workflows/generators/generator.py
+++ b/aiida_common_workflows/generators/generator.py
@@ -33,7 +33,7 @@ class InputGenerator(ProtocolRegistry, metaclass=abc.ABCMeta):
     def spec(cls) -> InputGeneratorSpec:
         """Return the specification of the input generator."""
         try:
-            return getattr(cls, '_spec')
+            return cls.__getattribute__(cls, '_spec')
         except AttributeError:
             try:
                 cls._spec: InputGeneratorSpec = cls._spec_cls()

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -4,6 +4,32 @@ import pytest
 from aiida import orm
 from aiida.plugins import WorkflowFactory
 
+from aiida_common_workflows.generators import InputGenerator
+
+
+class InputGeneratorA(InputGenerator):
+    """Dummy implementation of ``InputGenerator``."""
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input('a')
+
+    def _construct_builder(self, **kwargs):
+        """Not implemented."""
+
+
+class InputGeneratorB(InputGeneratorA):
+    """Dummy subclass of ``InputGeneratorA``."""
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input('b')
+
+    def _construct_builder(self, **kwargs):
+        """Not implemented."""
+
 
 def test_inputgen_constructor(generate_input_generator_cls):
     """Test the constructor of a subclass of ``InputGenerator``."""
@@ -16,9 +42,20 @@ def test_inputgen_constructor(generate_input_generator_cls):
     cls(process_class=WorkflowFactory('common_workflows.relax.siesta'))
 
 
+def test_spec():
+    """Test that ``spec`` classmethod creates new instance of generator spec and calls ``define``."""
+    InputGeneratorA.spec()
+    assert hasattr(InputGeneratorA, '_spec')
+    assert tuple(InputGeneratorA.spec().inputs.keys()) == ('a',)
+
+    InputGeneratorB.spec()
+    assert hasattr(InputGeneratorB, '_spec')
+    assert tuple(InputGeneratorB.spec().inputs.keys()) == ('a', 'b')
+
+
 def test_get_builder_immutable_kwargs(generate_input_generator_cls, generate_structure):
-    """
-    Test that calling ``get_builder`` does not mutate the ``kwargs`` when they are nodes.
+    """Test that calling ``get_builder`` does not mutate the ``kwargs`` when they are nodes.
+
     In this case a deepcopy would mute the node and therefore return a node with different uuid.
     """
 
@@ -33,15 +70,13 @@ def test_get_builder_immutable_kwargs(generate_input_generator_cls, generate_str
 
 
 def test_get_builder_mutable_kwargs(generate_input_generator_cls, monkeypatch):
-    """
-    Test that calling ``get_builder`` does mutate the ``kwargs`` when they are not nodes.
-    In this case, the implementation of ``get_builder`` ensure to deepcopy the ``kwargs``
-    before they will be available for use by any subclass of ``InputGenerator``.
-    In this specific case, we test a particulat input (``mutable``) that is modified inside
-    the ``get_builder`` of a ``generate_input_generator_cls`` implementation.
-    Even if this input is modified inside the implementation (see ``construct_builder`` here),
-    this does not affect the original ``kwargs`` that was passed in input of ``get_builder``.
-    It would not have been the case if the deepcopy was not in place.
+    """Test that calling ``get_builder`` does mutate the ``kwargs`` when they are not nodes.
+
+    In this case, the implementation of ``get_builder`` ensure to deepcopy the ``kwargs`` before they will be available
+    for use by any subclass of ``InputGenerator``. In this specific case, we test a particulat input (``mutable``) that
+    is modified inside the ``get_builder`` of a ``generate_input_generator_cls`` implementation. Even if this input is
+    modified inside the implementation (see ``construct_builder`` here), this does not affect the original ``kwargs``
+    that was passed in input of ``get_builder``. It would not have been the case if the deepcopy was not in place.
     """
 
     def construct_builder(self, **kwargs):
@@ -57,9 +92,7 @@ def test_get_builder_mutable_kwargs(generate_input_generator_cls, monkeypatch):
 
 
 def test_get_builder_immutable_kwargs_nested(generate_input_generator_cls, generate_structure):
-    """
-    Test that calling ``get_builder`` does not mutate the ``kwargs`` when they are nodes,
-    even if containing nested dictionaries.
+    """Test that calling ``get_builder`` does not mutate the ``kwargs`` when they are nodes, even if nested.
     """
     cls = generate_input_generator_cls(inputs_dict={'space.structure': orm.StructureData})
     generator = cls(process_class=WorkflowFactory('common_workflows.relax.siesta'))


### PR DESCRIPTION
Fixes #247 

The `spec` classmethod was using the global `getattr` method to check
whether the class already had the `_spec` class attribute defined, to
determine whether a new generator spec instance needed to be
instantiated and assigned to that attribute. However, this method will
go up the MRO of the class to see if any of its base classes already
have the attribute. This is a problem because the `_spec` attribute
should be subclass specific. If not, calling `spec()` on a base class
generator will lock the spec for all its subclasses as well, and so when
they call the spec, their own define method is not applied and they will
have the spec definition of the base class.

The solution is to replace `getattr` with `cls.__getattr__` which does
not subclasses and so remains subclass specific.