### PR TITLE
Add new `UNKNOWN` type to `ElectronicType`

### DIFF
--- a/aiida_common_workflows/common/types.py
+++ b/aiida_common_workflows/common/types.py
@@ -33,3 +33,4 @@ class ElectronicType(Enum):
     AUTOMATIC = 'automatic'
     METAL = 'metal'
     INSULATOR = 'insulator'
+    UNKNOWN = 'unknown'


### PR DESCRIPTION
Fixes #250 

The `UNKNOWN` type should indicate that the user doesn't know the
electronic type of the material and the input generator should use
inputs for a best guess. Typically this would be probably to treat the
system as a metal with some smearing. The already existing type
`AUTOMATIC` was being used for this purpose, but we want to reserve this
option for the use case where the generator actually generates a builder
for a workflow that will try and determine the electronic type through
actual simulation. This may be too ambitious and it is not sure if this
will be implemented in the future.