### PR TITLE
Introduce implementation of common interface for bands calculations

### DIFF
--- a/aiida_common_workflows/generators/generator.py
+++ b/aiida_common_workflows/generators/generator.py
@@ -5,7 +5,6 @@ import copy
 
 from aiida import engine, orm
 
-from ..protocol import ProtocolRegistry
 from .spec import InputGeneratorSpec
 
 __all__ = ('InputGenerator',)
@@ -24,7 +23,7 @@ def recursively_check_stored_nodes(obj):
     return copy.deepcopy(obj)
 
 
-class InputGenerator(ProtocolRegistry, metaclass=abc.ABCMeta):
+class InputGenerator(metaclass=abc.ABCMeta):
     """Base class for an input generator for a common workflow."""
 
     _spec_cls: InputGeneratorSpec = InputGeneratorSpec
@@ -50,9 +49,8 @@ class InputGenerator(ProtocolRegistry, metaclass=abc.ABCMeta):
         The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
         """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  #pylint: disable=unused-argument
         """Construct an instance of the input generator, validating the class attributes."""
-        super().__init__(*args, **kwargs)
 
         def raise_invalid(message):
             raise RuntimeError(f'invalid input generator `{self.__class__.__name__}`: {message}')

--- a/aiida_common_workflows/generators/generator.py
+++ b/aiida_common_workflows/generators/generator.py
@@ -49,7 +49,7 @@ class InputGenerator(metaclass=abc.ABCMeta):
         The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
         """
 
-    def __init__(self, *args, **kwargs):  #pylint: disable=unused-argument
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
         """Construct an instance of the input generator, validating the class attributes."""
 
         def raise_invalid(message):

--- a/aiida_common_workflows/protocol/registry.py
+++ b/aiida_common_workflows/protocol/registry.py
@@ -13,7 +13,7 @@ class ProtocolRegistry:
     _protocols = None
     _default_protocol = None
 
-    def __init__(self, *_, **__):
+    def __init__(self):
         """Construct an instance of the protocol registry, validating the class attributes set by the sub class."""
 
         def raise_invalid(message):

--- a/aiida_common_workflows/workflows/bands/__init__.py
+++ b/aiida_common_workflows/workflows/bands/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=undefined-variable
+"""Module with the base classes for the common bands workchains."""
+from .generator import *
+
+__all__ = (generator.__all__,)

--- a/aiida_common_workflows/workflows/bands/generator.py
+++ b/aiida_common_workflows/workflows/bands/generator.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""Module with base input generator for the common bands workchains."""
+import abc
+
+from aiida import orm, plugins
+
+from aiida_common_workflows.generators import InputGenerator
+
+__all__ = ('CommonBandsInputGenerator',)
+
+
+class CommonBandsInputGenerator(InputGenerator, metaclass=abc.ABCMeta):
+    """Input generator for the common bands workflow.
+
+    This class should be subclassed by implementations for specific quantum engines. After calling the super, they can
+    modify the ports defined here in the base class as well as add additional custom ports.
+    """
+
+    @classmethod
+    def define(cls, spec):
+        """Define the specification of the input generator.
+
+        The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
+        """
+        super().define(spec)
+        spec.input(
+            'bands_kpoints',
+            valid_type=plugins.DataFactory('array.kpoints'),
+            required=True,
+            help='The full list of kpoints where to calculate bands, in (direct) coordinates of the reciprocal space.'
+        )
+        spec.input(
+            'parent_folder',
+            valid_type=orm.RemoteData,
+            required=True,
+            help='Parent folder that contains file to restart from (density matrix, wave-functions..). What is used '
+            'is plugin dependent.'
+        )
+        spec.input_namespace(
+            'engines',
+            required=False,
+            help='Inputs for the quantum engines',
+        )
+        spec.input_namespace(
+            'engines.bands',
+            help='Inputs for the quantum engine performing the calculation of bands.',
+        )
+        spec.input(
+            'engines.bands.code',
+            valid_type=orm.Code,
+            serializer=orm.load_code,
+            help='The code instance to use for the bands calculation.',
+        )
+        spec.input(
+            'engines.bands.options',
+            valid_type=dict,
+            required=False,
+            help='Options for the bands calculations jobs.',
+        )

--- a/aiida_common_workflows/workflows/bands/siesta/__init__.py
+++ b/aiida_common_workflows/workflows/bands/siesta/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=undefined-variable
+"""Module with the implementations of the common bands workchain for Siesta."""
+from .generator import *
+from .workchain import *
+
+__all__ = (generator.__all__ + workchain.__all__)

--- a/aiida_common_workflows/workflows/bands/siesta/generator.py
+++ b/aiida_common_workflows/workflows/bands/siesta/generator.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Implementation of `aiida_common_workflows.common.bands.generator.CommonBandsInputGenerator` for SIESTA."""
+
+from aiida import engine, orm
+from aiida.common import LinkType
+
+from aiida_common_workflows.generators import CodeType
+
+from ..generator import CommonBandsInputGenerator
+
+__all__ = ('SiestaCommonBandsInputGenerator',)
+
+
+class SiestaCommonBandsInputGenerator(CommonBandsInputGenerator):
+    """Generator of inputs for the SiestaCommonBandsWorkChain"""
+
+    @classmethod
+    def define(cls, spec):
+        """Define the specification of the input generator.
+
+        The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
+        """
+        super().define(spec)
+        spec.inputs['engines']['bands']['code'].valid_type = CodeType('siesta.siesta')
+
+    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
+        """Construct a process builder based on the provided keyword arguments.
+
+        The keyword arguments will have been validated against the input generator specification.
+        """
+        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+        engines = kwargs.get('engines', None)
+        parent_folder = kwargs['parent_folder']
+        bands_kpoints = kwargs['bands_kpoints']
+
+        # From the parent folder, we retrieve the calculation that created it. Note
+        # that we are sure it exists (it wouldn't be the same for WorkChains). We then check
+        # that it is a SiestaCalculation and create the builder.
+        parent_siesta_calc = parent_folder.get_incoming(link_type=LinkType.CREATE).one().node
+        if parent_siesta_calc.process_type != 'aiida.calculations:siesta.siesta':
+            raise ValueError('The `parent_folder` has not been created by a SiestaCalculation')
+        builder_siesta_calc = parent_siesta_calc.get_builder_restart()
+
+        # Construct the builder of the `common_bands_wc` from the builder of a SiestaCalculation.
+        # Siesta specific: we have to eampty the metadata and put the resources in `options`.
+        builder_common_bands_wc = self.process_class.get_builder()
+        builder_common_bands_wc.options = orm.Dict(dict=builder_siesta_calc._data['metadata']['options'])  # pylint: disable=protected-access
+        builder_siesta_calc._data['metadata'] = {}  # pylint: disable=protected-access
+        for key, value in builder_siesta_calc._data.items():  # pylint: disable=protected-access
+            if value:
+                builder_common_bands_wc[key] = value
+
+        # Updated the structure (in case we have one in output)
+        if 'output_structure' in parent_siesta_calc.outputs:
+            builder_common_bands_wc.structure = parent_siesta_calc.outputs.output_structure
+
+        engb = engines['bands']
+        builder_common_bands_wc.code = engines['bands']['code']
+        if 'options' in engb:
+            builder_common_bands_wc.options = orm.Dict(dict=engines['bands']['options'])
+
+        # Set the `bandskpoints` and the `parent_calc_folder` for restart
+        builder_common_bands_wc.bandskpoints = bands_kpoints
+        builder_common_bands_wc.parent_calc_folder = parent_folder
+
+        return builder_common_bands_wc

--- a/aiida_common_workflows/workflows/bands/siesta/generator.py
+++ b/aiida_common_workflows/workflows/bands/siesta/generator.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.bands.generator.CommonBandsInputGenerator` for SIESTA."""
-
 from aiida import engine, orm
-from aiida.common import LinkType
 
 from aiida_common_workflows.generators import CodeType
 

--- a/aiida_common_workflows/workflows/bands/siesta/generator.py
+++ b/aiida_common_workflows/workflows/bands/siesta/generator.py
@@ -36,7 +36,7 @@ class SiestaCommonBandsInputGenerator(CommonBandsInputGenerator):
         # From the parent folder, we retrieve the calculation that created it. Note
         # that we are sure it exists (it wouldn't be the same for WorkChains). We then check
         # that it is a SiestaCalculation and create the builder.
-        parent_siesta_calc = parent_folder.get_incoming(link_type=LinkType.CREATE).one().node
+        parent_siesta_calc = parent_folder.creator
         if parent_siesta_calc.process_type != 'aiida.calculations:siesta.siesta':
             raise ValueError('The `parent_folder` has not been created by a SiestaCalculation')
         builder_siesta_calc = parent_siesta_calc.get_builder_restart()
@@ -44,9 +44,9 @@ class SiestaCommonBandsInputGenerator(CommonBandsInputGenerator):
         # Construct the builder of the `common_bands_wc` from the builder of a SiestaCalculation.
         # Siesta specific: we have to eampty the metadata and put the resources in `options`.
         builder_common_bands_wc = self.process_class.get_builder()
-        builder_common_bands_wc.options = orm.Dict(dict=builder_siesta_calc._data['metadata']['options'])  # pylint: disable=protected-access
-        builder_siesta_calc._data['metadata'] = {}  # pylint: disable=protected-access
-        for key, value in builder_siesta_calc._data.items():  # pylint: disable=protected-access
+        builder_common_bands_wc.options = orm.Dict(dict=dict(builder_siesta_calc.metadata.options))
+        builder_siesta_calc.metadata = {}
+        for key, value in builder_siesta_calc.items():
             if value:
                 builder_common_bands_wc[key] = value
 

--- a/aiida_common_workflows/workflows/bands/siesta/workchain.py
+++ b/aiida_common_workflows/workflows/bands/siesta/workchain.py
@@ -16,7 +16,6 @@ class SiestaCommonBandsWorkChain(CommonBandsWorkChain):
 
     def convert_outputs(self):
         """Convert the outputs of the sub workchain to the common output specification."""
-        self.report('Bands calculation concluded sucessfully, converting outputs')
         if 'bands' not in self.ctx.workchain.outputs:
             self.report('SiestaBaseWorkChain concluded without returning bands!')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED

--- a/aiida_common_workflows/workflows/bands/siesta/workchain.py
+++ b/aiida_common_workflows/workflows/bands/siesta/workchain.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for SIESTA."""
+from aiida.plugins import WorkflowFactory
+
+from ..workchain import CommonBandsWorkChain
+from .generator import SiestaCommonBandsInputGenerator
+
+__all__ = ('SiestaCommonBandsWorkChain',)
+
+
+class SiestaCommonBandsWorkChain(CommonBandsWorkChain):
+    """Implementation of `aiida_common_workflows.common.bands.workchain.CommonBandsWorkChain` for SIESTA."""
+
+    _process_class = WorkflowFactory('siesta.base')
+    _generator_class = SiestaCommonBandsInputGenerator
+
+    def convert_outputs(self):
+        """Convert the outputs of the sub workchain to the common output specification."""
+        self.report('Bands calculation concluded sucessfully, converting outputs')
+        if 'bands' not in self.ctx.workchain.outputs:
+            self.report('SiestaBaseWorkChain concluded without returning bands!')
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED
+        self.out('bands', self.ctx.workchain.outputs['bands'])

--- a/aiida_common_workflows/workflows/bands/workchain.py
+++ b/aiida_common_workflows/workflows/bands/workchain.py
@@ -53,8 +53,10 @@ class CommonBandsWorkChain(WorkChain, metaclass=ABCMeta):
         if not self.ctx.workchain.is_finished_ok:
             cls = self._process_class.__name__
             exit_status = self.ctx.workchain.exit_status
-            self.report(f'the `{cls}` failed with exit status {exit_status}')
+            self.report(f'{cls}<{self.ctx.workchain.pk}> failed with exit status {exit_status}.')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=cls, exit_status=exit_status)
+
+        self.report(f'{cls}<{self.ctx.workchain.pk}> finished successfully.')
 
     @abstractmethod
     def convert_outputs(self):

--- a/aiida_common_workflows/workflows/bands/workchain.py
+++ b/aiida_common_workflows/workflows/bands/workchain.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
-"""Module with base wrapper workchain for common structure relaxation workchains."""
+"""Module with base wrapper workchain for bands workchains."""
 from abc import ABCMeta, abstractmethod
 
 from aiida.engine import ToContext, WorkChain
-from aiida.orm import ArrayData, Float, RemoteData, StructureData, TrajectoryData
+from aiida.orm import BandsData
 
-from .generator import CommonRelaxInputGenerator
+from .generator import CommonBandsInputGenerator
 
-__all__ = ('CommonRelaxWorkChain',)
+__all__ = ('CommonBandsWorkChain',)
 
 
-class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
-    """Base workchain implementation that serves as a wrapper for common structure relaxation workchains.
+class CommonBandsWorkChain(WorkChain, metaclass=ABCMeta):
+    """Base workchain implementation that serves as a wrapper for bands workchains.
 
-    Subclasses should simply define the concrete plugin-specific relaxation workchain for the `_process_class` attribute
+    Subclasses should simply define the concrete plugin-specific bands workchain for the `_process_class` attribute
     and implement the `convert_outputs` class method to map the plugin specific outputs to the output spec of this
     common wrapper workchain.
     """
@@ -22,7 +22,7 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
     _generator_class = None
 
     @classmethod
-    def get_input_generator(cls) -> CommonRelaxInputGenerator:
+    def get_input_generator(cls) -> CommonBandsInputGenerator:
         """Return an instance of the input generator for this work chain.
 
         :return: input generator
@@ -39,20 +39,7 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
             cls.inspect_workchain,
             cls.convert_outputs,
         )
-        spec.output('relaxed_structure', valid_type=StructureData, required=False,
-            help='All cell dimensions and atomic positions are in Ångstrom.')
-        spec.output('forces', valid_type=ArrayData, required=False,
-            help='The final forces on all atoms in eV/Å.')
-        spec.output('stress', valid_type=ArrayData, required=False,
-            help='The final stress tensor in eV/Å^3.')
-        spec.output('trajectory', valid_type=TrajectoryData, required=False,
-            help='All cell dimensions and atomic positions are in Ångstrom.')
-        spec.output('total_energy', valid_type=Float, required=False,
-            help='Total energy in eV.')
-        spec.output('total_magnetization', valid_type=Float, required=False,
-            help='Total magnetization in Bohr magnetons.')
-        spec.output('remote_folder', valid_type=RemoteData, required=False,
-            help='Folder of the last run calculation.')
+        spec.output('bands', valid_type=BandsData, required=False, help='Energies in eV.')
         spec.exit_code(400, 'ERROR_SUB_PROCESS_FAILED',
             message='The `{cls}` workchain failed with exit status {exit_status}.')
 

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -6,11 +6,12 @@ from aiida import orm, plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators import ChoiceType, InputGenerator
+from aiida_common_workflows.protocol import ProtocolRegistry
 
 __all__ = ('CommonRelaxInputGenerator',)
 
 
-class CommonRelaxInputGenerator(InputGenerator, metaclass=abc.ABCMeta):
+class CommonRelaxInputGenerator(InputGenerator, ProtocolRegistry, metaclass=abc.ABCMeta):
     """Input generator for the common relax workflow.
 
     This class should be subclassed by implementations for specific quantum engines. After calling the super, they can

--- a/aiida_common_workflows/workflows/relax/siesta/workchain.py
+++ b/aiida_common_workflows/workflows/relax/siesta/workchain.py
@@ -49,3 +49,4 @@ class SiestaCommonRelaxWorkChain(CommonRelaxWorkChain):
         self.out('stress', res_dict['stress'])
         if 'stot' in self.ctx.workchain.outputs.output_parameters.attributes:
             self.out('total_magnetization', get_magn(self.ctx.workchain.outputs.output_parameters))
+        self.out('remote_folder', self.ctx.workchain.outputs.remote_folder)

--- a/aiida_common_workflows/workflows/relax/workchain.py
+++ b/aiida_common_workflows/workflows/relax/workchain.py
@@ -68,6 +68,7 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
             exit_status = self.ctx.workchain.exit_status
             self.report(f'the `{cls}` failed with exit status {exit_status}')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=cls, exit_status=exit_status)
+        self.report('Bands calculation concluded sucessfully, converting outputs')
 
     @abstractmethod
     def convert_outputs(self):

--- a/aiida_common_workflows/workflows/relax/workchain.py
+++ b/aiida_common_workflows/workflows/relax/workchain.py
@@ -66,9 +66,10 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
         if not self.ctx.workchain.is_finished_ok:
             cls = self._process_class.__name__
             exit_status = self.ctx.workchain.exit_status
-            self.report(f'the `{cls}` failed with exit status {exit_status}')
+            self.report(f'{cls}<{self.ctx.workchain.pk}> failed with exit status {exit_status}.')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=cls, exit_status=exit_status)
-        self.report('Bands calculation concluded sucessfully, converting outputs')
+
+        self.report(f'{cls}<{self.ctx.workchain.pk}> finished successfully.')
 
     @abstractmethod
     def convert_outputs(self):

--- a/setup.json
+++ b/setup.json
@@ -71,7 +71,8 @@
             "common_workflows.relax.orca = aiida_common_workflows.workflows.relax.orca.workchain:OrcaCommonRelaxWorkChain",
             "common_workflows.relax.quantum_espresso = aiida_common_workflows.workflows.relax.quantum_espresso.workchain:QuantumEspressoCommonRelaxWorkChain",
             "common_workflows.relax.siesta = aiida_common_workflows.workflows.relax.siesta.workchain:SiestaCommonRelaxWorkChain",
-            "common_workflows.relax.vasp = aiida_common_workflows.workflows.relax.vasp.workchain:VaspCommonRelaxWorkChain"
+            "common_workflows.relax.vasp = aiida_common_workflows.workflows.relax.vasp.workchain:VaspCommonRelaxWorkChain",
+            "common_workflows.bands.siesta = aiida_common_workflows.workflows.bands.siesta.workchain:SiestaCommonBandsWorkChain"
         ]
     },
     "license": "MIT License",

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -36,7 +36,7 @@ def test_inputgen_constructor(generate_input_generator_cls):
 
     cls = generate_input_generator_cls()
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         cls()
 
     cls(process_class=WorkflowFactory('common_workflows.relax.siesta'))

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -36,7 +36,7 @@ def test_inputgen_constructor(generate_input_generator_cls):
 
     cls = generate_input_generator_cls()
 
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         cls()
 
     cls(process_class=WorkflowFactory('common_workflows.relax.siesta'))

--- a/tests/workflows/bands/test_implementations.py
+++ b/tests/workflows/bands/test_implementations.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso` module."""
+# pylint: disable=redefined-outer-name
+from aiida import engine, orm, plugins
+import pytest
+
+from aiida_common_workflows.generators.ports import InputGeneratorPort
+from aiida_common_workflows.plugins import get_workflow_entry_point_names
+from aiida_common_workflows.workflows.bands.workchain import CommonBandsWorkChain
+
+
+@pytest.fixture(scope='function', params=get_workflow_entry_point_names('bands'))
+def workchain(request) -> CommonBandsWorkChain:
+    """Fixture that parametrizes over all the registered implementations of the ``CommonBandsWorkChain``."""
+    return plugins.WorkflowFactory(request.param)
+
+
+def test_spec(workchain):
+    """Test that the input specification of all implementations respects the common interface."""
+    generator = workchain.get_input_generator()
+    generator_spec = generator.spec()
+
+    required_ports = {
+        'bands_kpoints': {
+            'valid_type': plugins.DataFactory('array.kpoints')
+        },
+        'parent_folder': {
+            'valid_type': orm.RemoteData
+        },
+        'engines': {},
+    }
+
+    for port_name, values in required_ports.items():
+        assert isinstance(generator_spec.inputs.get_port(port_name), (InputGeneratorPort, engine.PortNamespace))
+
+        if 'valid_type' in values:
+            assert generator_spec.inputs.get_port(port_name).valid_type is values['valid_type']

--- a/tests/workflows/bands/test_workchain.py
+++ b/tests/workflows/bands/test_workchain.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=abstract-method,arguments-differ,redefined-outer-name
+"""Tests for the :mod:`aiida_common_workflows.workflows.bands.workchain` module."""
+from aiida.plugins import WorkflowFactory
+import pytest
+
+from aiida_common_workflows.plugins import get_workflow_entry_point_names
+from aiida_common_workflows.workflows.bands import CommonBandsInputGenerator
+from aiida_common_workflows.workflows.bands.workchain import CommonBandsWorkChain
+
+
+@pytest.fixture(scope='function', params=get_workflow_entry_point_names('bands'))
+def workchain(request) -> CommonBandsWorkChain:
+    """Fixture that parametrizes over all the registered implementations of the ``CommonBandsWorkChain``."""
+    return WorkflowFactory(request.param)
+
+
+def test_workchain_class(workchain):
+    """Test that each registered common bands workchain can be imported and subclasses ``CommonBandsWorkChain``."""
+    assert issubclass(workchain, CommonBandsWorkChain)
+
+
+def test_get_input_generator(workchain):
+    """Test that each registered common bands workchain defines the associated input generator."""
+    generator = workchain.get_input_generator()
+    assert isinstance(generator, CommonBandsInputGenerator)
+    assert issubclass(generator.process_class, CommonBandsWorkChain)


### PR DESCRIPTION
The `InputGenerator` for the bands accepts as inputs only
1) a list of kpoints where to calculate the bands
2) an engine dictionary containing the code and computational resources
3) a "parent_folder" from which all the other inputs should be obtained.
This implementation requires a small change on the generator abstract class,
now the `InputGenerator` is not children of `ProtocolRegistry`, since
there might be inputs generators that do not require a protocol.