### PR TITLE
Three bugs sorted

### DIFF
--- a/aiida_common_workflows/workflows/bands/generator.py
+++ b/aiida_common_workflows/workflows/bands/generator.py
@@ -48,7 +48,7 @@ class CommonBandsInputGenerator(InputGenerator, metaclass=abc.ABCMeta):
             'engines.bands.code',
             valid_type=orm.Code,
             serializer=orm.load_code,
-            help='The code instance to use for the geometry optimization.',
+            help='The code instance to use for the bands calculation.',
         )
         spec.input(
             'engines.bands.options',

--- a/aiida_common_workflows/workflows/bands/generator.py
+++ b/aiida_common_workflows/workflows/bands/generator.py
@@ -38,22 +38,21 @@ class CommonBandsInputGenerator(InputGenerator, metaclass=abc.ABCMeta):
         )
         spec.input_namespace(
             'engines',
-            required=False,
             help='Inputs for the quantum engines',
         )
         spec.input_namespace(
             'engines.bands',
-            help='Inputs for the quantum engine performing the calculation of bands.',
+            help='Inputs for the quantum engine performing the bands calculation.',
         )
         spec.input(
             'engines.bands.code',
             valid_type=orm.Code,
             serializer=orm.load_code,
-            help='The code instance to use for the bands calculation.',
+            help='The code instance to use for the geometry optimization.',
         )
         spec.input(
             'engines.bands.options',
             valid_type=dict,
             required=False,
-            help='Options for the bands calculations jobs.',
+            help='Options for the bands calculation jobs.',
         )

--- a/aiida_common_workflows/workflows/bands/siesta/generator.py
+++ b/aiida_common_workflows/workflows/bands/siesta/generator.py
@@ -45,7 +45,7 @@ class SiestaCommonBandsInputGenerator(CommonBandsInputGenerator):
         builder_common_bands_wc.options = orm.Dict(dict=dict(builder_siesta_calc.metadata.options))
         builder_siesta_calc.metadata = {}
         for key, value in builder_siesta_calc.items():
-            if value:
+            if value and key != 'metadata':
                 builder_common_bands_wc[key] = value
 
         # Updated the structure (in case we have one in output)

--- a/aiida_common_workflows/workflows/bands/workchain.py
+++ b/aiida_common_workflows/workflows/bands/workchain.py
@@ -50,8 +50,9 @@ class CommonBandsWorkChain(WorkChain, metaclass=ABCMeta):
 
     def inspect_workchain(self):
         """Inspect the terminated workchain."""
+        cls = self._process_class.__name__
+
         if not self.ctx.workchain.is_finished_ok:
-            cls = self._process_class.__name__
             exit_status = self.ctx.workchain.exit_status
             self.report(f'{cls}<{self.ctx.workchain.pk}> failed with exit status {exit_status}.')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=cls, exit_status=exit_status)

--- a/aiida_common_workflows/workflows/relax/workchain.py
+++ b/aiida_common_workflows/workflows/relax/workchain.py
@@ -63,8 +63,8 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
 
     def inspect_workchain(self):
         """Inspect the terminated workchain."""
+        cls = self._process_class.__name__
         if not self.ctx.workchain.is_finished_ok:
-            cls = self._process_class.__name__
             exit_status = self.ctx.workchain.exit_status
             self.report(f'{cls}<{self.ctx.workchain.pk}> failed with exit status {exit_status}.')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=cls, exit_status=exit_status)


### PR DESCRIPTION
1) The return of a report was failing since one variable was called
   before definition
2) The help for input ports of the `CommonBandsInputGenerator` were
   wrong
3) A fix only concerning the siesta implementation that was passing
   a wrong input (metadata) to the workchain