### PR TITLE
Allow for library specific FFT lengths

### DIFF
--- a/aiida_common_workflows/workflows/relax/cp2k/protocol.yml
+++ b/aiida_common_workflows/workflows/relax/cp2k/protocol.yml
@@ -346,6 +346,8 @@ verification-PBE-v1-DZVP-GTH:
   kpoints_distance: 0.06
   basis_pseudo: dzvp-pbe-gth.yml
   GLOBAL:
+    EXTENDED_FFT_LENGTHS: True
+    PREFERRED_DIAG_LIBRARY: ScaLAPACK
     PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
   FORCE_EVAL:
     METHOD:         QUICKSTEP
@@ -460,6 +462,8 @@ verification-PBE-v1-TZV2P-GTH:
   kpoints_distance: 0.06
   basis_pseudo: tzv2p-pbe-gth.yml
   GLOBAL:
+    EXTENDED_FFT_LENGTHS: True
+    PREFERRED_DIAG_LIBRARY: ScaLAPACK
     PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
   FORCE_EVAL:
     METHOD:         QUICKSTEP


### PR DESCRIPTION
Always use ScaLAPACK for matrix multiplications instead of the default ELPA