### PR TITLE
`quantum_espresso`: Fix stress units

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -31,7 +31,8 @@
         "aiida-vasp",
         "pymatgen<=2021.3.3",
         "sqlalchemy<1.4",
-	"ase!=3.20.*"
+        "ase!=3.20.*",
+        "pint~=0.16"
     ],
     "extras_require": {
         "docs": [


### PR DESCRIPTION
Fixes #262 

Currently, the `extract_from_trajectory` calculation function simply
passes the stress from the last frame of the trajectory to the
`stress` output. However, the units of this output array are in GPa, not
the agreed upon eV/angstrom^3.

Here we use the `pint` library to convert the `stress` array into the
correct units.