### PR TITLE
QE: Add `verification-pbe-v1` protocol

### DIFF
--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -155,7 +155,7 @@ class EquationOfStateWorkChain(WorkChain):
     def run_init(self):
         """
         Run the first workchain.
-        
+
         This is run for the first (usually the smallest) volume in the set of scale factors,
         which is then used as a reference workchain for all other calculations.
         Each plugin should then reuse the relevant parameters from this reference

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/extractors.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/extractors.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Post-processing extractor functions for the ``QuantumEspressoCommonRelaxWorkChain``.
+"""
+
+from aiida.common import LinkType
+from aiida.orm import WorkChainNode
+
+from .workchain import QuantumEspressoCommonRelaxWorkChain
+
+
+def get_ts_energy(common_relax_workchain: QuantumEspressoCommonRelaxWorkChain) -> float:
+    """ Return the T * S value of a concluded ``QuantumEspressoCommonRelaxWorkChain``.
+
+    Here, T is the fictitious temperature due to the use of smearing and S is the entropy. This "smearing contribution"
+    to the free energy in Quantum ESPRESSO is expressed as -T * S:
+
+        smearing contrib. (-TS)   =      -0.00153866 Ry
+
+    And the ``PwParser`` also maintains this sign, i.e. it only converts the units to eV.
+
+    :param common_relax_workchain: ``QuantumEspressoCommonRelaxWorkChain`` for which to extract the smearing energy.
+    :returns: The T*S value in eV.
+    """
+    if not isinstance(common_relax_workchain, WorkChainNode):
+        return ValueError('The input is not a workchain (instance of `WorkChainNode`)')
+    if common_relax_workchain.process_class != QuantumEspressoCommonRelaxWorkChain:
+        return ValueError('The input workchain is not a `QuantumEspressoCommonRelaxWorkChain`')
+
+    qe_relax_wc = common_relax_workchain.get_outgoing(link_type=LinkType.CALL_WORK).one().node
+    return -qe_relax_wc.outputs.output_parameters['energy_smearing']

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/protocol.yml
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/protocol.yml
@@ -1,0 +1,25 @@
+verification-pbe-v1:
+  description: Main protocol for the ACWF verification study - SSSP version
+  base:
+    pseudo_family: &pseudo_family 'SSSP/1.2/PBE/precision'
+    kpoints_distance: &kpoints_distance 0.06
+    meta_parameters:
+        conv_thr_per_atom: &conv_thr_per_atom 0.1e-9
+        etot_conv_thr_per_atom: 0.5e-5
+    pw:
+      parameters:
+        CONTROL:
+            forc_conv_thr: 0.5e-4
+        SYSTEM:
+          smearing: &smearing fd
+          degauss: &degauss 0.0045
+  base_final_scf:
+    pseudo_family: *pseudo_family
+    kpoints_distance: *kpoints_distance
+    meta_parameters:
+        conv_thr_per_atom: *conv_thr_per_atom
+    pw:
+      parameters:
+        SYSTEM:
+          smearing: *smearing
+          degauss: *degauss

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ disable = [
     'duplicate-code',
     'no-member',
     'too-few-public-methods',
+    "wrong-import-order"
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Add the `verification-pbe-v1` protocol for Quantum ESPRESSO by adding a
new `protocol.yml` file to the `relax` subpackage. In order to use this
protocol without the `aiida-quantumespresso`
`PwRelaxWorkChain.get_builder_from_protocol()` method failing, we check
if the user specified protocol is in the defaults (`fast`, `moderate`,
`precise`). If not, we try to load it from the local protocols encoded
in the `aiida-common-workflows` package.

Also adds the `clean_workdir` input to the
`QuantumEspressoCommonRelaxInputGenerator`.