### PR TITLE
DevOps: Fix pre-commit by upgrading `isort==5.12.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         ]
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
     -   id: isort
 

--- a/setup.json
+++ b/setup.json
@@ -30,6 +30,7 @@
         "aiida-siesta>=1.2.0",
         "aiida-vasp",
         "pymatgen<=2021.3.3",
+        "numpy<1.24.0",
         "sqlalchemy<1.4",
         "ase!=3.20.*",
         "pint~=0.16",


### PR DESCRIPTION
This version fixes a bug that was introduced by breaking changes in a recent release of `poetry-core`.