### PR TITLE
CLI: Call `sys.exit` for launch command if process fails

### DIFF
--- a/aiida_common_workflows/cli/utils.py
+++ b/aiida_common_workflows/cli/utils.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 """Module with utitlies for the CLI."""
+import sys
+
 import click
 
 
 def echo_process_results(node):
     """Display a formatted table of the outputs registered for the given process node.
+
+    If the node corresponds to a process that was actually run and that did not finish with a zero exit code, this
+    function will call ``sys.exit(1)``.
 
     :param node: the `ProcessNode` of a terminated process.
     """
@@ -31,6 +36,9 @@ def echo_process_results(node):
 
     for triple in sorted(outputs, key=lambda triple: triple.link_label):
         click.echo(f'{triple.link_label:25s} {triple.node.__class__.__name__}<{triple.node.pk}> ')
+
+    if not node.is_finished_ok:
+        sys.exit(1)
 
 
 def launch_process(process, daemon, **inputs):


### PR DESCRIPTION
Fixes #289 

For testing purposes it is convenient to know whether the process launched through the `acwf launch` commands finished successfully. To this end, the commands will now call `sys.exit(1)` if the process did not finish with a zero exit code (or excepted or was killed).