### PR TITLE
🔧 Pin `abipy` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    'abipy',
+    'abipy==0.9.6',
     'aiida-abinit~=0.4.0',
     'aiida-bigdft>=0.2.6',
     'aiida-castep>=1.2.0a5',


### PR DESCRIPTION
Due to the close dependency of `abipy` on `pymatgen`, and our own dependencies on `pymatgen`, it is challenging to install both packages in one environment.

Version `0.9.6` of `abipy` was released after some specific changes were made to ensure it can install with our current `master` branch, which we intend to release for the oxide verification paper. Since it is highly likely that the next version of `abipy` will make changes to the code to update it for `pymatgen` versions we no longer support, we pin the version to this release.