### PR TITLE
Dependencies: Switch to using `ruff` for linting and formatting

### DIFF
--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -17,8 +17,11 @@ def get_version_from_module(content: str) -> str:
 
     try:
         return next(
-            ast.literal_eval(statement.value) for statement in module.body if isinstance(statement, ast.Assign)
-            for target in statement.targets if isinstance(target, ast.Name) and target.id == '__version__'
+            ast.literal_eval(statement.value)
+            for statement in module.body
+            if isinstance(statement, ast.Assign)
+            for target in statement.targets
+            if isinstance(target, ast.Name) and target.id == '__version__'
         )
     except StopIteration as exception:
         raise IOError('Unable to find the `__version__` attribute in the module.') from exception
@@ -30,7 +33,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     TAG_PREFIX = 'refs/tags/v'
     assert args.GITHUB_REF.startswith(TAG_PREFIX), f'GITHUB_REF should start with "{TAG_PREFIX}": {args.GITHUB_REF}'
-    tag_version = args.GITHUB_REF[len(TAG_PREFIX):]
+    tag_version = args.GITHUB_REF[len(TAG_PREFIX) :]
     package_version = get_version_from_module(Path('aiida_common_workflows/__init__.py').read_text(encoding='utf-8'))
     error_message = f'The tag version `{tag_version}` is different from the package version `{package_version}`'
     assert tag_version == package_version, error_message

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,24 +13,9 @@ repos:
     hooks:
     -   id: flynt
 
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-    -   id: isort
-
--   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.31.0
-    hooks:
-    -   id: yapf
-        name: yapf
-        types: [python]
-        args: ['-i']
-        additional_dependencies: ['toml']
-
--   repo: local
-    hooks:
-    -   id: pylint
-        name: pylint
-        entry: pylint
-        types: [python]
-        language: system
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.9
+  hooks:
+  - id: ruff-format
+  - id: ruff
+    args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/aiida_common_workflows/cli/__init__.py
+++ b/aiida_common_workflows/cli/__init__.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=wrong-import-position,wildcard-import
+
 """Module for the command line interface."""
 import click_completion
 
 # Activate the completion of parameter types provided by the click_completion package
 click_completion.init()
-
-from .launch import cmd_launch
-from .plot import cmd_plot
-from .root import cmd_root

--- a/aiida_common_workflows/cli/launch.py
+++ b/aiida_common_workflows/cli/launch.py
@@ -2,8 +2,8 @@
 """Commands to launch common workflows."""
 import functools
 
-from aiida.cmdline.params import types
 import click
+from aiida.cmdline.params import types
 
 from aiida_common_workflows.plugins import get_workflow_entry_point_names, load_workflow_entry_point
 
@@ -41,7 +41,7 @@ def cmd_launch():
 @options.CODES()
 @options.PROTOCOL(
     type=click.Choice(['fast', 'moderate', 'precise', 'verification-PBE-v1', 'verification-PBE-v1-sirius']),
-    default='fast'
+    default='fast',
 )
 @options.RELAX_TYPE()
 @options.ELECTRONIC_TYPE()
@@ -57,10 +57,25 @@ def cmd_launch():
 @options.REFERENCE_WORKCHAIN()
 @options.ENGINE_OPTIONS()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
-def cmd_relax(  # pylint: disable=too-many-branches
-    plugin, structure, codes, protocol, relax_type, electronic_type, spin_type, threshold_forces, threshold_stress,
-    number_machines, number_mpi_procs_per_machine, number_cores_per_mpiproc, wallclock_seconds, daemon,
-    magnetization_per_site, reference_workchain, engine_options, show_engines
+def cmd_relax(  # noqa: PLR0912,PLR0913,PLR0915
+    plugin,
+    structure,
+    codes,
+    protocol,
+    relax_type,
+    electronic_type,
+    spin_type,
+    threshold_forces,
+    threshold_stress,
+    number_machines,
+    number_mpi_procs_per_machine,
+    number_cores_per_mpiproc,
+    wallclock_seconds,
+    daemon,
+    magnetization_per_site,
+    reference_workchain,
+    engine_options,
+    show_engines,
 ):
     """Relax a crystal structure using the common relax workflow for one of the existing plugin implementations.
 
@@ -69,7 +84,7 @@ def cmd_relax(  # pylint: disable=too-many-branches
     If no code is installed for at least one of the calculation engines, the command will fail.
     Use the `--show-engine` flag to display the required calculation engines for the selected plugin workflow.
     """
-    # pylint: disable=too-many-locals,too-many-statements
+
     process_class = load_workflow_entry_point('relax', plugin)
     generator = process_class.get_input_generator()
 
@@ -81,19 +96,19 @@ def cmd_relax(  # pylint: disable=too-many-branches
     if len(number_machines) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-machines'
+            param_hint='--number-machines',
         )
 
     if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-mpi-procs-per-machine'
+            param_hint='--number-mpi-procs-per-machine',
         )
 
     if number_cores_per_mpiproc is not None and len(number_cores_per_mpiproc) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-cores-per-mpiproc'
+            param_hint='--number-cores-per-mpiproc',
         )
 
     if wallclock_seconds is None:
@@ -102,7 +117,7 @@ def cmd_relax(  # pylint: disable=too-many-branches
     if len(wallclock_seconds) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--wallclock-seconds'
+            param_hint='--wallclock-seconds',
         )
 
     if not generator.is_valid_protocol(protocol):
@@ -195,10 +210,24 @@ def cmd_relax(  # pylint: disable=too-many-branches
 @options.MAGNETIZATION_PER_SITE()
 @options.ENGINE_OPTIONS()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
-def cmd_eos(  # pylint: disable=too-many-branches,too-many-statements
-    plugin, structure, codes, protocol, relax_type, electronic_type, spin_type, threshold_forces, threshold_stress,
-    number_machines, number_mpi_procs_per_machine, number_cores_per_mpiproc, wallclock_seconds, daemon,
-    magnetization_per_site, engine_options, show_engines
+def cmd_eos(  # noqa: PLR0912,PLR0913,PLR0915
+    plugin,
+    structure,
+    codes,
+    protocol,
+    relax_type,
+    electronic_type,
+    spin_type,
+    threshold_forces,
+    threshold_stress,
+    number_machines,
+    number_mpi_procs_per_machine,
+    number_cores_per_mpiproc,
+    wallclock_seconds,
+    daemon,
+    magnetization_per_site,
+    engine_options,
+    show_engines,
 ):
     """Compute the equation of state of a crystal structure using the common relax workflow.
 
@@ -207,7 +236,7 @@ def cmd_eos(  # pylint: disable=too-many-branches,too-many-statements
     If no code is installed for at least one of the calculation engines, the command will fail.
     Use the `--show-engine` flag to display the required calculation engines for the selected plugin workflow.
     """
-    # pylint: disable=too-many-locals
+
     from aiida_common_workflows.plugins import get_entry_point_name_from_class
     from aiida_common_workflows.workflows.eos import EquationOfStateWorkChain
 
@@ -222,19 +251,19 @@ def cmd_eos(  # pylint: disable=too-many-branches,too-many-statements
     if len(number_machines) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-machines'
+            param_hint='--number-machines',
         )
 
     if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-mpi-procs-per-machine'
+            param_hint='--number-mpi-procs-per-machine',
         )
 
     if number_cores_per_mpiproc is not None and len(number_cores_per_mpiproc) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-cores-per-mpiproc'
+            param_hint='--number-cores-per-mpiproc',
         )
 
     if wallclock_seconds is None:
@@ -243,7 +272,7 @@ def cmd_eos(  # pylint: disable=too-many-branches,too-many-statements
     if len(wallclock_seconds) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--wallclock-seconds'
+            param_hint='--wallclock-seconds',
         )
 
     if not generator.is_valid_protocol(protocol):
@@ -332,10 +361,21 @@ def cmd_eos(  # pylint: disable=too-many-branches,too-many-statements
 @options.MAGNETIZATION_PER_SITE()
 @options.ENGINE_OPTIONS()
 @click.option('--show-engines', is_flag=True, help='Show information on the required calculation engines.')
-def cmd_dissociation_curve(  # pylint: disable=too-many-branches
-    plugin, structure, codes, protocol, electronic_type, spin_type, number_machines, number_mpi_procs_per_machine,
+def cmd_dissociation_curve(  # noqa: PLR0912, PLR0913
+    plugin,
+    structure,
+    codes,
+    protocol,
+    electronic_type,
+    spin_type,
+    number_machines,
+    number_mpi_procs_per_machine,
     number_cores_per_mpiproc,
-    wallclock_seconds, daemon, magnetization_per_site, engine_options, show_engines
+    wallclock_seconds,
+    daemon,
+    magnetization_per_site,
+    engine_options,
+    show_engines,
 ):
     """Compute the dissociation curve of a diatomic molecule using the common relax workflow.
 
@@ -347,7 +387,7 @@ def cmd_dissociation_curve(  # pylint: disable=too-many-branches
     If no code is installed for at least one of the calculation engines, the command will fail.
     Use the `--show-engine` flag to display the required calculation engines for the selected plugin workflow.
     """
-    # pylint: disable=too-many-locals
+
     from aiida_common_workflows.plugins import get_entry_point_name_from_class
     from aiida_common_workflows.workflows.dissociation import DissociationCurveWorkChain
     from aiida_common_workflows.workflows.relax.generator import RelaxType
@@ -363,19 +403,19 @@ def cmd_dissociation_curve(  # pylint: disable=too-many-branches
     if len(number_machines) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-machines'
+            param_hint='--number-machines',
         )
 
     if number_mpi_procs_per_machine is not None and len(number_mpi_procs_per_machine) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-mpi-procs-per-machine'
+            param_hint='--number-mpi-procs-per-machine',
         )
 
     if number_cores_per_mpiproc is not None and len(number_cores_per_mpiproc) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--number-cores-per-mpiproc'
+            param_hint='--number-cores-per-mpiproc',
         )
 
     if wallclock_seconds is None:
@@ -384,7 +424,7 @@ def cmd_dissociation_curve(  # pylint: disable=too-many-branches
     if len(wallclock_seconds) != number_engines:
         raise click.BadParameter(
             f'{process_class.__name__} has {number_engines} engine steps, so requires {number_engines} values',
-            param_hint='--wallclock-seconds'
+            param_hint='--wallclock-seconds',
         )
 
     if not generator.is_valid_protocol(protocol):

--- a/aiida_common_workflows/cli/options.py
+++ b/aiida_common_workflows/cli/options.py
@@ -3,9 +3,9 @@
 import json
 import pathlib
 
+import click
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils.decorators import with_dbenv
-import click
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 
@@ -23,10 +23,11 @@ DEFAULT_STRUCTURES_MAPPING = {
 def get_workchain_plugins():
     """Return the registered entry point names for the ``CommonRelaxWorkChain``."""
     from aiida.plugins import entry_point
+
     group = 'aiida.workflows'
     entry_point_prefix = 'common_workflows.relax.'
     names = entry_point.get_entry_point_names(group)
-    return {name[len(entry_point_prefix):] for name in names if name.startswith(entry_point_prefix)}
+    return {name[len(entry_point_prefix) :] for name in names if name.startswith(entry_point_prefix)}
 
 
 def get_relax_types_eos():
@@ -100,20 +101,19 @@ class StructureDataParamType(click.Choice):
 
         try:
             structure = StructureData(ase=ase.io.read(filepath))
-        except Exception as exception:  # pylint: disable=broad-except
+        except Exception as exception:
             raise click.BadParameter(
                 f'file `{value}` could not be parsed into a `StructureData`: {exception}'
             ) from exception
 
-        duplicate = QueryBuilder().append(
-            StructureData,
-            filters={
-                'extras._aiida_hash': structure.base.caching._get_hash()  # pylint: disable=protected-access
-            }
-        ).first()
+        duplicate = (
+            QueryBuilder()
+            .append(StructureData, filters={'extras._aiida_hash': structure.base.caching._get_hash()})
+            .first()
+        )
 
         if duplicate:
-            return duplicate[0]  # pylint: disable=unsubscriptable-object
+            return duplicate[0]
 
         return structure
 
@@ -127,7 +127,7 @@ CODES = options.OverridableOption(
     help='One or multiple codes identified by their ID, UUID or label. What codes are required is dependent on the '
     'selected plugin and can be shown using the `--show-engines` option. If no explicit codes are specified, one will '
     'be loaded from the database based on the required input plugins. If multiple codes are matched, a random one will '
-    'be selected.'
+    'be selected.',
 )
 
 STRUCTURE = options.OverridableOption(
@@ -136,7 +136,7 @@ STRUCTURE = options.OverridableOption(
     type=StructureDataParamType(),
     default='Si',
     help='Select a structure: either choose one of the default structures listed above, or an existing `StructureData` '
-    'identifier, or a file on disk with a structure definition that can be parsed by `ase`.'
+    'identifier, or a file on disk with a structure definition that can be parsed by `ase`.',
 )
 
 PROTOCOL = options.OverridableOption(
@@ -145,7 +145,7 @@ PROTOCOL = options.OverridableOption(
     type=click.Choice(['fast', 'moderate', 'precise', 'verification-PBE-v1', 'verification-PBE-v1-sirius']),
     default='fast',
     show_default=True,
-    help='Select the protocol with which the inputs for the workflow should be generated.'
+    help='Select the protocol with which the inputs for the workflow should be generated.',
 )
 
 RELAX_TYPE = options.OverridableOption(
@@ -155,7 +155,7 @@ RELAX_TYPE = options.OverridableOption(
     default='positions',
     show_default=True,
     callback=lambda ctx, param, value: RelaxType(value),
-    help='Select the relax type with which the workflow should be run.'
+    help='Select the relax type with which the workflow should be run.',
 )
 
 ELECTRONIC_TYPE = options.OverridableOption(
@@ -165,7 +165,7 @@ ELECTRONIC_TYPE = options.OverridableOption(
     default='metal',
     show_default=True,
     callback=lambda ctx, param, value: ElectronicType(value),
-    help='Select the electronic type with which the workflow should be run.'
+    help='Select the electronic type with which the workflow should be run.',
 )
 
 SPIN_TYPE = options.OverridableOption(
@@ -175,21 +175,21 @@ SPIN_TYPE = options.OverridableOption(
     default='none',
     show_default=True,
     callback=lambda ctx, param, value: SpinType(value),
-    help='Select the spin type with which the workflow should be run.'
+    help='Select the spin type with which the workflow should be run.',
 )
 
 THRESHOLD_FORCES = options.OverridableOption(
     '--threshold-forces',
     type=click.FLOAT,
     required=False,
-    help='Optional convergence threshold for the forces. Note that not all plugins may support this option.'
+    help='Optional convergence threshold for the forces. Note that not all plugins may support this option.',
 )
 
 THRESHOLD_STRESS = options.OverridableOption(
     '--threshold-stress',
     type=click.FLOAT,
     required=False,
-    help='Optional convergence threshold for the stress. Note that not all plugins may support this option.'
+    help='Optional convergence threshold for the stress. Note that not all plugins may support this option.',
 )
 
 DAEMON = options.OverridableOption(
@@ -197,7 +197,7 @@ DAEMON = options.OverridableOption(
     '--daemon',
     is_flag=True,
     default=False,
-    help='Submit the process to the daemon instead of running it locally.'
+    help='Submit the process to the daemon instead of running it locally.',
 )
 
 WALLCLOCK_SECONDS = options.OverridableOption(
@@ -207,7 +207,7 @@ WALLCLOCK_SECONDS = options.OverridableOption(
     type=click.INT,
     metavar='VALUES',
     required=False,
-    help='Define the wallclock seconds to request for each engine step.'
+    help='Define the wallclock seconds to request for each engine step.',
 )
 
 NUMBER_MACHINES = options.OverridableOption(
@@ -217,7 +217,7 @@ NUMBER_MACHINES = options.OverridableOption(
     type=click.INT,
     metavar='VALUES',
     required=False,
-    help='Define the number of machines to request for each engine step.'
+    help='Define the number of machines to request for each engine step.',
 )
 
 NUMBER_MPI_PROCS_PER_MACHINE = options.OverridableOption(
@@ -227,7 +227,7 @@ NUMBER_MPI_PROCS_PER_MACHINE = options.OverridableOption(
     type=click.INT,
     metavar='VALUES',
     required=False,
-    help='Define the number of MPI processes per machine to request for each engine step.'
+    help='Define the number of MPI processes per machine to request for each engine step.',
 )
 
 NUMBER_CORES_PER_MPIPROC = options.OverridableOption(
@@ -237,7 +237,7 @@ NUMBER_CORES_PER_MPIPROC = options.OverridableOption(
     type=click.INT,
     metavar='VALUES',
     required=False,
-    help='Define the number of cores (threads) per MPI processes to use for each engine step.'
+    help='Define the number of cores (threads) per MPI processes to use for each engine step.',
 )
 
 MAGNETIZATION_PER_SITE = options.OverridableOption(
@@ -245,7 +245,7 @@ MAGNETIZATION_PER_SITE = options.OverridableOption(
     type=click.FLOAT,
     cls=options.MultipleValueOption,
     required=False,
-    help='Optional list containing the initial spin polarization per site in units of electrons.'
+    help='Optional list containing the initial spin polarization per site in units of electrons.',
 )
 
 PRECISIONS = options.OverridableOption(
@@ -254,7 +254,7 @@ PRECISIONS = options.OverridableOption(
     cls=options.MultipleValueOption,
     type=click.INT,
     required=False,
-    help='Specify the precision of floats used when printing them to stdout with the `--print-table` option.'
+    help='Specify the precision of floats used when printing them to stdout with the `--print-table` option.',
 )
 
 PRINT_TABLE = options.OverridableOption(
@@ -266,7 +266,7 @@ REFERENCE_WORKCHAIN = options.OverridableOption(
     '--reference-workchain',
     type=types.WorkflowParamType(),
     required=False,
-    help='An instance of a completed workchain of the same type as would be run for the given plugin.'
+    help='An instance of a completed workchain of the same type as would be run for the given plugin.',
 )
 
 OUTPUT_FILE = options.OverridableOption(
@@ -283,5 +283,5 @@ ENGINE_OPTIONS = options.OverridableOption(
     'with bash escaping, using single quotes, and using instead double quotes for valid JSON strings! The backticks '
     'are here used instead only to delimit code). This will add the `account` option to the "relax" engine. If your '
     'common workflow needs multiple engines, you should pass the options for each engine that you need to modify. '
-    ' Suggestion: use the `--show-engines` option to know which engines are required by this common workflow.'
+    ' Suggestion: use the `--show-engines` option to know which engines are required by this common workflow.',
 )

--- a/aiida_common_workflows/cli/plot.py
+++ b/aiida_common_workflows/cli/plot.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Commands to plot results from a workflow."""
+import click
 from aiida.cmdline.params import arguments
 from aiida.cmdline.utils import echo
 from aiida.plugins import WorkflowFactory
-import click
 
 from . import options
 from .root import cmd_root
@@ -24,7 +24,7 @@ def cmd_plot():
 @options.OUTPUT_FILE()
 def cmd_plot_eos(workflow, precisions, print_table, output_file):
     """Plot the results from an `EquationOfStateWorkChain`."""
-    # pylint: disable=too-many-locals
+
     from aiida.common import LinkType
     from tabulate import tabulate
 
@@ -65,7 +65,7 @@ def cmd_plot_eos(workflow, precisions, print_table, output_file):
     if print_table:
         tabulate_inputs = {
             'tabular_data': list(zip(volumes, energies, magnetizations)),
-            'headers': ['Volume (Å^3)', 'Energy (eV)', 'Total magnetization (μB)']
+            'headers': ['Volume (Å^3)', 'Energy (eV)', 'Total magnetization (μB)'],
         }
 
         if precisions is not None:
@@ -97,7 +97,7 @@ def cmd_plot_eos(workflow, precisions, print_table, output_file):
 @options.OUTPUT_FILE()
 def cmd_plot_dissociation_curve(workflow, precisions, print_table, output_file):
     """Plot the results from a `DissociationCurveWorkChain`."""
-    # pylint: disable=too-many-locals
+
     from aiida.common import LinkType
     from tabulate import tabulate
 
@@ -138,7 +138,7 @@ def cmd_plot_dissociation_curve(workflow, precisions, print_table, output_file):
     if print_table:
         tabulate_inputs = {
             'tabular_data': list(zip(distances, energies, magnetizations)),
-            'headers': ['Distance (Å)', 'Energy (eV)', 'Total magnetization (μB)']
+            'headers': ['Distance (Å)', 'Energy (eV)', 'Total magnetization (μB)'],
         }
 
         if precisions is not None:

--- a/aiida_common_workflows/cli/root.py
+++ b/aiida_common_workflows/cli/root.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Command line interface ``acwf``."""
+import click
 from aiida.cmdline.groups import VerdiCommandGroup
 from aiida.cmdline.params import options, types
-import click
 
 
 @click.group('acwf', cls=VerdiCommandGroup, context_settings={'help_option_names': ['-h', '--help']})

--- a/aiida_common_workflows/common/__init__.py
+++ b/aiida_common_workflows/common/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-builtin,undefined-variable
 """Module for resources common to the entire `aiida-common-workflows` package."""
-from .types import *
+from .types import ElectronicType, RelaxType, SpinType
 
-all = (types.__all__,)
+__all__ = ('ElectronicType', 'SpinType', 'RelaxType')

--- a/aiida_common_workflows/common/visualization/dissociation.py
+++ b/aiida_common_workflows/common/visualization/dissociation.py
@@ -6,10 +6,7 @@ import matplotlib.pyplot as plt
 
 
 def get_dissociation_plot(
-    distances: typing.List[float],
-    energies: typing.List[float],
-    unit_distance: str = 'Å',
-    unit_energy: str = 'eV'
+    distances: typing.List[float], energies: typing.List[float], unit_distance: str = 'Å', unit_energy: str = 'eV'
 ) -> plt:
     """Plot the dissociation curve for a given set of distances and energies.
 

--- a/aiida_common_workflows/common/visualization/eos.py
+++ b/aiida_common_workflows/common/visualization/eos.py
@@ -6,19 +6,19 @@ import matplotlib.pyplot as plt
 import numpy
 
 
-def birch_murnaghan(V, E0, V0, B0, B01):
+def birch_murnaghan(V, E0, V0, B0, B01):  # noqa: N803
     """Compute energy by Birch Murnaghan formula."""
-    # pylint: disable=invalid-name
-    r = (V0 / V)**(2. / 3.)
-    return E0 + 9. / 16. * B0 * V0 * (r - 1.)**2 * (2. + (B01 - 4.) * (r - 1.))
+
+    r = (V0 / V) ** (2.0 / 3.0)
+    return E0 + 9.0 / 16.0 * B0 * V0 * (r - 1.0) ** 2 * (2.0 + (B01 - 4.0) * (r - 1.0))
 
 
 def fit_birch_murnaghan_params(volumes, energies):
     """Fit Birch Murnaghan parameters."""
-    # pylint: disable=invalid-name
+
     from scipy.optimize import curve_fit
 
-    params, covariance = curve_fit(  # pylint: disable=unbalanced-tuple-unpacking
+    params, covariance = curve_fit(
         birch_murnaghan,
         xdata=volumes,
         ydata=energies,
@@ -26,18 +26,15 @@ def fit_birch_murnaghan_params(volumes, energies):
             energies.min(),  # E0
             volumes.mean(),  # V0
             0.1,  # B0
-            3.,  # B01
+            3.0,  # B01
         ),
-        sigma=None
+        sigma=None,
     )
     return params, covariance
 
 
 def get_eos_plot(
-    volumes: typing.List[float],
-    energies: typing.List[float],
-    unit_volume: str = 'Å^3',
-    unit_energy: str = 'eV'
+    volumes: typing.List[float], energies: typing.List[float], unit_volume: str = 'Å^3', unit_energy: str = 'eV'
 ) -> plt:
     """Plot the Equation of State for a given set of volumes and energies
 

--- a/aiida_common_workflows/generators/generator.py
+++ b/aiida_common_workflows/generators/generator.py
@@ -49,7 +49,7 @@ class InputGenerator(metaclass=abc.ABCMeta):
         The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
         """
 
-    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def __init__(self, *args, **kwargs):
         """Construct an instance of the input generator, validating the class attributes."""
 
         def raise_invalid(message):

--- a/aiida_common_workflows/plugins/__init__.py
+++ b/aiida_common_workflows/plugins/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable,invalid-all-object
 """Module with utilities for working with the plugins provided by this plugin package."""
-from .entry_point import *
+from .entry_point import get_entry_point_name_from_class, get_workflow_entry_point_names, load_workflow_entry_point
 
-__all__ = (entry_point.__all__,)
+__all__ = ('get_workflow_entry_point_names', 'get_entry_point_name_from_class', 'load_workflow_entry_point')

--- a/aiida_common_workflows/plugins/entry_point.py
+++ b/aiida_common_workflows/plugins/entry_point.py
@@ -22,12 +22,13 @@ def get_workflow_entry_point_names(workflow: str, leaf: bool = False) -> typing.
     if not leaf:
         return [name for name in entry_points_names if name.startswith(prefix)]
 
-    return [name[len(prefix):] for name in entry_points_names if name.startswith(prefix)]
+    return [name[len(prefix) :] for name in entry_points_names if name.startswith(prefix)]
 
 
 def get_entry_point_name_from_class(cls) -> str:
     """Return the full entry point string for the given class."""
     from aiida.plugins.entry_point import get_entry_point_from_class
+
     return get_entry_point_from_class(cls.__module__, cls.__name__)[1]
 
 

--- a/aiida_common_workflows/protocol/__init__.py
+++ b/aiida_common_workflows/protocol/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
-"""Module with utilities to define and implement workchain protocols."""
-from .registry import *
 
-__all__ = (registry.__all__,)
+"""Module with utilities to define and implement workchain protocols."""
+from .registry import ProtocolRegistry
+
+__all__ = ('ProtocolRegistry',)

--- a/aiida_common_workflows/protocol/registry.py
+++ b/aiida_common_workflows/protocol/registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=unsupported-membership-test,unsubscriptable-object
+
 """Module with base protocol registry."""
 import copy
 import typing

--- a/aiida_common_workflows/utils/sphinx_extension/input_generator.py
+++ b/aiida_common_workflows/utils/sphinx_extension/input_generator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Define a Restructured Text directive to auto-document :class:`aiida_common_workflows.generators.InputGenerator`."""
 import inspect
+import typing as t
 
 from aiida.common.utils import get_object_from_string
 from aiida.engine import Process
@@ -22,6 +23,7 @@ def setup_extension(app):
 
 class CommonInputGeneratorDocumenter(ClassDocumenter):
     """Sphinx documenter class for AiiDA Processes."""
+
     directivetype = 'common-input-generator'
     objtype = 'common-input-generator'
     priority = 10
@@ -39,7 +41,7 @@ class CommonInputGeneratorDirective(SphinxDirective):
     final_argument_whitespace = True
 
     EXPAND_NAMESPACES_FLAG = 'expand-namespaces'
-    option_spec = {'module': directives.unchanged_required, EXPAND_NAMESPACES_FLAG: directives.flag}
+    option_spec: t.ClassVar = {'module': directives.unchanged_required, EXPAND_NAMESPACES_FLAG: directives.flag}
     signature = 'InputGenerator'
     annotation = 'common-input-generator'
 
@@ -55,7 +57,7 @@ class CommonInputGeneratorDirective(SphinxDirective):
 
         Includes importing the process class.
         """
-        # pylint: disable=attribute-defined-outside-init
+
         load_profile()
 
         self.class_name = self.arguments[0].split('(')[0]

--- a/aiida_common_workflows/workflows/bands/__init__.py
+++ b/aiida_common_workflows/workflows/bands/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the base classes for the common bands workchains."""
 from .generator import *
 

--- a/aiida_common_workflows/workflows/bands/generator.py
+++ b/aiida_common_workflows/workflows/bands/generator.py
@@ -27,14 +27,14 @@ class CommonBandsInputGenerator(InputGenerator, metaclass=abc.ABCMeta):
             'bands_kpoints',
             valid_type=plugins.DataFactory('core.array.kpoints'),
             required=True,
-            help='The full list of kpoints where to calculate bands, in (direct) coordinates of the reciprocal space.'
+            help='The full list of kpoints where to calculate bands, in (direct) coordinates of the reciprocal space.',
         )
         spec.input(
             'parent_folder',
             valid_type=orm.RemoteData,
             required=True,
             help='Parent folder that contains file to restart from (density matrix, wave-functions..). What is used '
-            'is plugin dependent.'
+            'is plugin dependent.',
         )
         spec.input_namespace(
             'engines',

--- a/aiida_common_workflows/workflows/bands/siesta/__init__.py
+++ b/aiida_common_workflows/workflows/bands/siesta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common bands workchain for Siesta."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/bands/siesta/generator.py
+++ b/aiida_common_workflows/workflows/bands/siesta/generator.py
@@ -26,7 +26,7 @@ class SiestaCommonBandsInputGenerator(CommonBandsInputGenerator):
 
         The keyword arguments will have been validated against the input generator specification.
         """
-        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+
         engines = kwargs.get('engines', None)
         parent_folder = kwargs['parent_folder']
         bands_kpoints = kwargs['bands_kpoints']

--- a/aiida_common_workflows/workflows/bands/workchain.py
+++ b/aiida_common_workflows/workflows/bands/workchain.py
@@ -27,7 +27,7 @@ class CommonBandsWorkChain(WorkChain, metaclass=ABCMeta):
 
         :return: input generator
         """
-        return cls._generator_class(process_class=cls)  # pylint: disable=not-callable
+        return cls._generator_class(process_class=cls)
 
     @classmethod
     def define(cls, spec):

--- a/aiida_common_workflows/workflows/eos.py
+++ b/aiida_common_workflows/workflows/eos.py
@@ -23,7 +23,7 @@ def validate_inputs(value, _):
 
     try:
         generator.get_builder(structure=value['structure'], **value['generator_inputs'])
-    except Exception as exc:  # pylint: disable=broad-except
+    except Exception as exc:
         return f'`{generator.__class__.__name__}.get_builder()` fails for the provided `generator_inputs`: {exc}'
 
 
@@ -69,7 +69,7 @@ def validate_relax_type(value, _):
 def scale_structure(structure: orm.StructureData, scale_factor: orm.Float) -> orm.StructureData:
     """Scale the structure with the given scaling factor."""
     ase = structure.get_ase().copy()
-    ase.set_cell(ase.get_cell() * float(scale_factor)**(1 / 3), scale_atoms=True)
+    ase.set_cell(ase.get_cell() * float(scale_factor) ** (1 / 3), scale_atoms=True)
     return orm.StructureData(ase=ase)
 
 
@@ -144,11 +144,8 @@ class EquationOfStateWorkChain(WorkChain):
         if reference_workchain is not None:
             base_inputs['reference_workchain'] = reference_workchain
 
-        builder = process_class.get_input_generator().get_builder(
-            **base_inputs,
-            **self.inputs.generator_inputs
-        )
-        builder._update(**self.inputs.get('sub_process', {}))  # pylint: disable=protected-access
+        builder = process_class.get_input_generator().get_builder(**base_inputs, **self.inputs.generator_inputs)
+        builder._update(**self.inputs.get('sub_process', {}))
 
         return builder, structure
 
@@ -172,7 +169,7 @@ class EquationOfStateWorkChain(WorkChain):
         """Check that the first workchain finished successfully or abort the workchain."""
         if not self.ctx.children[0].is_finished_ok:
             self.report('Initial sub process did not finish successful so aborting the workchain.')
-            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=self.inputs.sub_process_class)  # pylint: disable=no-member
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=self.inputs.sub_process_class)
 
     def run_eos(self):
         """Run the sub process at each scale factor to compute the structure volume and total energy."""
@@ -188,7 +185,7 @@ class EquationOfStateWorkChain(WorkChain):
     def inspect_eos(self):
         """Inspect all children workflows to make sure they finished successfully."""
         if any(not child.is_finished_ok for child in self.ctx.children):
-            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=self.inputs.sub_process_class)  # pylint: disable=no-member
+            return self.exit_codes.ERROR_SUB_PROCESS_FAILED.format(cls=self.inputs.sub_process_class)
 
         for index, child in enumerate(self.ctx.children):
             try:

--- a/aiida_common_workflows/workflows/relax/__init__.py
+++ b/aiida_common_workflows/workflows/relax/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the base classes for the common structure relaxation workchains."""
 from .generator import *
 

--- a/aiida_common_workflows/workflows/relax/abinit/__init__.py
+++ b/aiida_common_workflows/workflows/relax/abinit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for Abinit."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/abinit/workchain.py
+++ b/aiida_common_workflows/workflows/relax/abinit/workchain.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Abinit."""
+import numpy as np
 from aiida import orm
 from aiida.common import exceptions
 from aiida.engine import calcfunction
 from aiida_abinit.workflows.base import AbinitBaseWorkChain
-import numpy as np
 
 from ..workchain import CommonRelaxWorkChain
 from .generator import AbinitCommonRelaxInputGenerator

--- a/aiida_common_workflows/workflows/relax/bigdft/__init__.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for BigDFT."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/bigdft/generator.py
+++ b/aiida_common_workflows/workflows/relax/bigdft/generator.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for BigDFT."""
+import typing as t
+
 from aiida import engine, plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
@@ -17,7 +19,7 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `BigDftCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
-    _protocols = {
+    _protocols: t.ClassVar = {
         'fast': {
             'description': 'This profile should be chosen if accurate forces are required, but there is no need for '
             'extremely accurate energies.',
@@ -31,23 +33,21 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
                     'idsx': 0,
                     'gnrm_cv': 1e-8,
                     'hgrids': 0.4,
-                    'disablesym': 'no'
+                    'disablesym': 'no',
                 },
                 'mix': {
                     'iscf': 17,
                     'itrpmax': 200,
-                    'rpnrm_cv': 1.E-12,
+                    'rpnrm_cv': 1.0e-12,
                     'norbsempty': 120,
                     'tel': 0.00225,
                     'occopt': 2,
                     'alphamix': 0.8,
-                    'alphadiis': 1.0
-                }
+                    'alphadiis': 1.0,
+                },
             },
-            'inputdict_linear': {
-                'import': 'linear'
-            },
-            'kpoints_distance': 142  # Equivalent length of K-space resolution (Bohr)
+            'inputdict_linear': {'import': 'linear'},
+            'kpoints_distance': 142,  # Equivalent length of K-space resolution (Bohr)
         },
         'moderate': {
             'description': 'This profile should be chosen if accurate forces are required, but there is no need for '
@@ -62,23 +62,21 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
                     'idsx': 0,
                     'gnrm_cv': 1e-8,
                     'hgrids': 0.4,
-                    'disablesym': 'no'
+                    'disablesym': 'no',
                 },
                 'mix': {
                     'iscf': 17,
                     'itrpmax': 200,
-                    'rpnrm_cv': 1.E-12,
+                    'rpnrm_cv': 1.0e-12,
                     'norbsempty': 120,
                     'tel': 0.00225,
                     'occopt': 2,
                     'alphamix': 0.8,
-                    'alphadiis': 1.0
-                }
+                    'alphadiis': 1.0,
+                },
             },
-            'inputdict_linear': {
-                'import': 'linear'
-            },
-            'kpoints_distance': 274
+            'inputdict_linear': {'import': 'linear'},
+            'kpoints_distance': 274,
         },
         'precise': {
             'description': 'This profile should be chosen if accurate forces are required, but there is no need for '
@@ -93,23 +91,21 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
                     'idsx': 0,
                     'gnrm_cv': 1e-8,
                     'hgrids': 0.3,
-                    'disablesym': 'no'
+                    'disablesym': 'no',
                 },
                 'mix': {
                     'iscf': 17,
                     'itrpmax': 200,
-                    'rpnrm_cv': 1.E-12,
+                    'rpnrm_cv': 1.0e-12,
                     'norbsempty': 120,
                     'tel': 0.00225,
                     'occopt': 2,
                     'alphamix': 0.8,
-                    'alphadiis': 1.0
-                }
+                    'alphadiis': 1.0,
+                },
             },
-            'inputdict_linear': {
-                'import': 'linear'
-            },
-            'kpoints_distance': 274
+            'inputdict_linear': {'import': 'linear'},
+            'kpoints_distance': 274,
         },
         'verification-PBE-v1': {
             'description': 'Protocol used for bulk run of EoS verification project',
@@ -123,23 +119,21 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
                     'idsx': 0,
                     'gnrm_cv': 1e-8,
                     'hgrids': 0.4,
-                    'disablesym': 'no'
+                    'disablesym': 'no',
                 },
                 'mix': {
                     'iscf': 17,
                     'itrpmax': 200,
-                    'rpnrm_cv': 1.E-12,
+                    'rpnrm_cv': 1.0e-12,
                     'norbsempty': 120,
                     'tel': 0.00225,
                     'occopt': 2,
                     'alphamix': 0.8,
-                    'alphadiis': 1.0
-                }
+                    'alphadiis': 1.0,
+                },
             },
-            'inputdict_linear': {
-                'import': 'linear'
-            },
-            'kpoints_distance': 274
+            'inputdict_linear': {'import': 'linear'},
+            'kpoints_distance': 274,
         },
     }
 
@@ -156,12 +150,12 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         spec.inputs['electronic_type'].valid_type = ChoiceType((ElectronicType.METAL, ElectronicType.INSULATOR))
         spec.inputs['engines']['relax']['code'].valid_type = CodeType('bigdft')
 
-    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
+    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:  # noqa: PLR0912
         """Construct a process builder based on the provided keyword arguments.
 
         The keyword arguments will have been validated against the input generator specification.
         """
-        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+
         import copy
 
         structure = kwargs['structure']
@@ -192,28 +186,33 @@ class BigDftCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             else:
                 hgrids = logfile.get('dft').get('hgrids')
             first_hgrid = hgrids[0] if isinstance(hgrids, list) else hgrids
-            inputdict['dft']['hgrids'] = first_hgrid * builder.BigDFT.structure.cell_lengths[0] / \
-                reference_workchain.inputs.structure.cell_lengths[0]
+            inputdict['dft']['hgrids'] = (
+                first_hgrid
+                * builder.BigDFT.structure.cell_lengths[0]
+                / reference_workchain.inputs.structure.cell_lengths[0]
+            )
 
         if electronic_type is ElectronicType.METAL:
             if 'mix' not in inputdict:
                 inputdict['mix'] = {}
-            inputdict['mix'].update({
-                'iscf': 17,
-                'itrpmax': 200,
-                'rpnrm_cv': 1.E-12,
-                'norbsempty': 120,
-                'tel': 0.01,
-                'alphamix': 0.8,
-                'alphadiis': 1.0
-            })
+            inputdict['mix'].update(
+                {
+                    'iscf': 17,
+                    'itrpmax': 200,
+                    'rpnrm_cv': 1.0e-12,
+                    'norbsempty': 120,
+                    'tel': 0.01,
+                    'alphamix': 0.8,
+                    'alphadiis': 1.0,
+                }
+            )
         if spin_type is SpinType.NONE:
             inputdict['dft'].update({'nspin': 1})
         elif spin_type is SpinType.COLLINEAR:
             inputdict['dft'].update({'nspin': 2})
 
         if magnetization_per_site:
-            for (i, atom) in enumerate(inputdict['posinp']['positions']):
+            for i, atom in enumerate(inputdict['posinp']['positions']):
                 atom['IGSpin'] = int(magnetization_per_site[i])
         # correctly set kpoints from protocol fast and moderate. If precise, use the ones from set_inputfile/set_kpt
         if self.get_protocol(protocol).get('kpoints_distance'):

--- a/aiida_common_workflows/workflows/relax/castep/__init__.py
+++ b/aiida_common_workflows/workflows/relax/castep/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for CASTEP"""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/castep/extractors.py
+++ b/aiida_common_workflows/workflows/relax/castep/extractors.py
@@ -32,6 +32,6 @@ def get_ts_energy(common_relax_workchain):
     e_ks = castep_base_wc.outputs.output_parameters['total energy']
     free_e = castep_base_wc.outputs.output_parameters['free energy']
 
-    ts = e_ks - free_e  #pylint: disable=invalid-name
+    ts = e_ks - free_e
 
     return ts

--- a/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -2,27 +2,26 @@
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for CASTEP"""
 import collections
 import copy
-from math import pi
 import pathlib
 import typing as t
+from math import pi
 
+import yaml
 from aiida import engine, orm, plugins
 from aiida.common import exceptions
 from aiida_castep.data import get_pseudos_from_structure
 from aiida_castep.data.otfg import OTFGGroup
-import yaml
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators import ChoiceType, CodeType
 
 from ..generator import CommonRelaxInputGenerator
 
-# pylint: disable=import-outside-toplevel, too-many-branches, too-many-statements
 KNOWN_BUILTIN_FAMILIES = ('C19', 'NCP19', 'QC5', 'C17', 'C9')
 
 __all__ = ('CastepCommonRelaxInputGenerator',)
 
-StructureData = plugins.DataFactory('core.structure')  # pylint: disable=invalid-name
+StructureData = plugins.DataFactory('core.structure')
 
 
 class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
@@ -59,12 +58,12 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         spec.inputs['electronic_type'].valid_type = ChoiceType((ElectronicType.METAL, ElectronicType.INSULATOR))
         spec.inputs['engines']['relax']['code'].valid_type = CodeType('castep.castep')
 
-    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
+    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:  # noqa: PLR0912,PLR0915
         """Construct a process builder based on the provided keyword arguments.
 
         The keyword arguments will have been validated against the input generator specification.
         """
-        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+
         structure = kwargs['structure']
         engines = kwargs['engines']
         protocol = kwargs['protocol']
@@ -127,7 +126,7 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             # Symmetry should be off, unless QUANTISATION_AXIS is supplied
             # that would be too advanced, here I just turn it off
             param.pop('symmetry_generate', None)
-        #elif spin_type == SpinType.SPIN_ORBIT:
+        # elif spin_type == SpinType.SPIN_ORBIT:
         #    param['spin_treatment'] = 'noncollinear'
         #    param['spin_orbit_coupling'] = True
         #    param.pop('symmetry_generate', None)
@@ -157,13 +156,13 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         # Process electronic type
         # for plane-wave DFT density mixing is most efficient for both metal and insulators
         # these days. Here we stick to the default of CASTEP and do nothing here.
-        #if electronic_type == ElectronicType.METAL:
+        # if electronic_type == ElectronicType.METAL:
         #    # Use fine kpoints grid for all metallic calculations
         # No need to do this since the default is spacing is sufficiently fine
         #    override['base']['kpoints_spacing'] = 0.03
-        #elif electronic_type in (ElectronicType.INSULATOR, ElectronicType.AUTOMATIC):
+        # elif electronic_type in (ElectronicType.INSULATOR, ElectronicType.AUTOMATIC):
         #    pass
-        #else:
+        # else:
         #    raise ValueError('Unsupported `electronic_type` {}.'.format(electronic_type))
 
         # Raise the cut off energy for very soft pseudopotentials
@@ -186,7 +185,7 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         ensure_otfg_family(pseudos_family)
 
         builder = self.process_class.get_builder()
-        inputs = generate_inputs(self.process_class._process_class, protocol, code, structure, override)  # pylint: disable=protected-access
+        inputs = generate_inputs(self.process_class._process_class, protocol, code, structure, override)
 
         # Finally, apply the logic for previous workchain
         if reference_workchain:
@@ -204,7 +203,7 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             inputs['calc']['kpoints'] = previous_kpoints
             inputs['base'].pop('kpoints_spacing', None)
 
-        builder._update(inputs)  # pylint: disable=protected-access
+        builder._update(inputs)
 
         return builder
 
@@ -233,7 +232,7 @@ def generate_inputs(
     protocol: t.Dict,
     code: orm.Code,
     structure: orm.StructureData,
-    override: t.Dict[str, t.Any] = None
+    override: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Dict[str, t.Any]:
     """Generate the input parameters for the given workchain type for a given code, structure and pseudo family.
 
@@ -249,7 +248,7 @@ def generate_inputs(
     :param override: a dictionary to override specific inputs
     :return: input dictionary
     """
-    # pylint: disable=too-many-arguments,unused-argument
+
     from aiida.common.lang import type_check
 
     family_name = protocol['relax']['base']['pseudos_family']
@@ -262,9 +261,9 @@ def generate_inputs(
         family = protocol['relax']['base']['pseudos_family']
         raise ValueError(f'protocol `{name}` requires the `{family}` `pseudos family` but could not be found.') from exc
 
-    CastepCalculation = plugins.CalculationFactory('castep.castep')  # pylint: disable=invalid-name
-    CastepBaseWorkChain = plugins.WorkflowFactory('castep.base')  # pylint: disable=invalid-name
-    CastepRelaxWorkChain = plugins.WorkflowFactory('castep.relax')  # pylint: disable=invalid-name
+    CastepCalculation = plugins.CalculationFactory('castep.castep')  # noqa: N806
+    CastepBaseWorkChain = plugins.WorkflowFactory('castep.base')  # noqa: N806
+    CastepRelaxWorkChain = plugins.WorkflowFactory('castep.relax')  # noqa: N806
 
     type_check(structure, orm.StructureData)
 
@@ -288,7 +287,7 @@ def generate_inputs_relax(
     code: orm.Code,
     structure: orm.StructureData,
     otfg_family: OTFGGroup,
-    override: t.Dict[str, t.Any] = None
+    override: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Dict[str, t.Any]:
     """Generate the inputs for the `CastepCommonRelaxWorkChain` for a given code, structure and pseudo potential family.
 
@@ -313,7 +312,7 @@ def generate_inputs_relax(
         'base': merged['base'],
         'calc': calc,
         'structure': structure,
-        'relax_options': orm.Dict(dict=merged['relax_options'])
+        'relax_options': orm.Dict(dict=merged['relax_options']),
     }
 
     return dictionary
@@ -324,7 +323,7 @@ def generate_inputs_base(
     code: orm.Code,
     structure: orm.StructureData,
     otfg_family: OTFGGroup,
-    override: t.Dict[str, t.Any] = None
+    override: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Dict[str, t.Any]:
     """Generate the inputs for the `CastepBaseWorkChain` for a given code, structure and pseudo potential family.
 
@@ -362,7 +361,7 @@ def generate_inputs_calculation(
     code: orm.Code,
     structure: orm.StructureData,
     otfg_family: OTFGGroup,
-    override: t.Dict[str, t.Any] = None
+    override: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Dict[str, t.Any]:
     """Generate the inputs for the `CastepCalculation` for a given code, structure and pseudo potential family.
 
@@ -374,6 +373,7 @@ def generate_inputs_calculation(
     :return: the fully defined input dictionary.
     """
     from aiida_castep.calculations.helper import CastepHelper
+
     override = {} if not override else override.get('calc', {})
     # This merge perserves the merged `parameters` in the override
     merged_calc = recursive_merge(protocol['calc'], override)
@@ -401,7 +401,7 @@ def generate_inputs_calculation(
         'code': code,
         'parameters': orm.Dict(dict=param),
         'pseudos': get_pseudos_from_structure(structure, otfg_family.label),
-        'metadata': merged_calc.get('metadata', {})
+        'metadata': merged_calc.get('metadata', {}),
     }
     # Add the settings input if present
     if 'settings' in merged_calc:

--- a/aiida_common_workflows/workflows/relax/cp2k/__init__.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for CP2K."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/cp2k/workchain.py
+++ b/aiida_common_workflows/workflows/relax/cp2k/workchain.py
@@ -2,17 +2,17 @@
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for CP2K."""
 import re
 
+import numpy as np
 from aiida import orm
 from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
-import numpy as np
 
 from ..workchain import CommonRelaxWorkChain
 from .generator import Cp2kCommonRelaxInputGenerator
 
 __all__ = ('Cp2kCommonRelaxWorkChain',)
 
-Cp2kBaseWorkChain = WorkflowFactory('cp2k.base')  # pylint: disable=invalid-name
+Cp2kBaseWorkChain = WorkflowFactory('cp2k.base')
 
 EV_A3_TO_BAR = 1602176.6208
 HA_BOHR_TO_EV_A = 51.42208619083232
@@ -37,8 +37,11 @@ def get_forces_output_folder(folder, structure):
     except FileNotFoundError:
         try:
             content = folder.get_object_content('aiida-requested-forces-1_0.xyz')
-            lines = re.search('Atom   Kind   Element(.*?)SUM OF ATOMIC FORCES', content,
-                              flags=re.S).group(1).splitlines()[1:-1]
+            lines = (
+                re.search('Atom   Kind   Element(.*?)SUM OF ATOMIC FORCES', content, flags=re.S)
+                .group(1)
+                .splitlines()[1:-1]
+            )
             forces_position = 3
         except FileNotFoundError:
             return None
@@ -46,7 +49,7 @@ def get_forces_output_folder(folder, structure):
     # Extract forces.
     forces_array = np.empty((natoms, 3))
     for i, line in enumerate(lines):
-        forces_array[i] = [float(s) for s in line.split()[forces_position:forces_position + 3]]
+        forces_array[i] = [float(s) for s in line.split()[forces_position : forces_position + 3]]
     forces = orm.ArrayData()
     forces.set_array(name='forces', array=forces_array * HA_BOHR_TO_EV_A)
     return forces

--- a/aiida_common_workflows/workflows/relax/fleur/__init__.py
+++ b/aiida_common_workflows/workflows/relax/fleur/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for FLEUR."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/fleur/extractors.py
+++ b/aiida_common_workflows/workflows/relax/fleur/extractors.py
@@ -29,12 +29,12 @@ def get_ts_energy(common_relax_workchain):
     fleur_calc_out = fleur_relax_wc.outputs.last_scf.last_calc
 
     output_parameters = fleur_calc_out.output_parameters
-    ts = None  #pylint: disable=invalid-name
+    ts = None
     if 'ts_energy' in output_parameters.keys():
-        ts = output_parameters['ts_energy']  #pylint: disable=invalid-name
+        ts = output_parameters['ts_energy']
     elif fleur_relax_wc.is_finished_ok:
-        #This check makes sure that the parsing worked before so we don't get
-        #nasty surprises in load_outxml
+        # This check makes sure that the parsing worked before so we don't get
+        # nasty surprises in load_outxml
 
         with fleur_calc_out.retrieved.open('out.xml', 'rb') as file:
             xmltree, schema_dict = load_outxml(file)
@@ -46,6 +46,6 @@ def get_ts_energy(common_relax_workchain):
             pass
         else:
             if ts_all:
-                ts = ts_all[-1] * HTR_TO_EV  #pylint: disable=invalid-name
+                ts = ts_all[-1] * HTR_TO_EV
 
     return ts

--- a/aiida_common_workflows/workflows/relax/fleur/workchain.py
+++ b/aiida_common_workflows/workflows/relax/fleur/workchain.py
@@ -11,7 +11,7 @@ __all__ = ('FleurCommonRelaxWorkChain',)
 
 
 @calcfunction
-def get_forces_from_trajectory(trajectory):  # pylint: disable=unused-argument
+def get_forces_from_trajectory(trajectory):
     """Calcfunction to get forces from trajectory"""
     forces = orm.ArrayData()
     # currently the fleur relax workchain does not output trajectory data,

--- a/aiida_common_workflows/workflows/relax/gaussian/__init__.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for Gaussian."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/gaussian/generator.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/generator.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Gaussian."""
 import copy
+import typing as t
 
-from aiida import engine, orm, plugins
 import numpy as np
+from aiida import engine, orm, plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators import ChoiceType, CodeType
@@ -22,7 +23,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `GaussianCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
-    _protocols = {
+    _protocols: t.ClassVar = {
         'fast': {
             'description': 'Optimal performance, minimal accuracy.',
             'functional': 'PBEPBE',
@@ -30,7 +31,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             'route_parameters': {
                 'nosymm': None,
                 'opt': 'loose',
-            }
+            },
         },
         'moderate': {
             'description': 'Moderate performance, moderate accuracy.',
@@ -40,7 +41,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
                 'int': 'ultrafine',
                 'nosymm': None,
                 'opt': None,
-            }
+            },
         },
         'precise': {
             'description': 'Low performance, high accuracy',
@@ -50,8 +51,8 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
                 'int': 'superfine',
                 'nosymm': None,
                 'opt': 'tight',
-            }
-        }
+            },
+        },
     }
 
     @classmethod
@@ -66,12 +67,12 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         spec.inputs['electronic_type'].valid_type = ChoiceType((ElectronicType.METAL, ElectronicType.INSULATOR))
         spec.inputs['engines']['relax']['code'].valid_type = CodeType('gaussian')
 
-    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
+    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:  # noqa: PLR0912,PLR0915
         """Construct a process builder based on the provided keyword arguments.
 
         The keyword arguments will have been validated against the input generator specification.
         """
-        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+
         structure = kwargs['structure']
         engines = kwargs['engines']
         protocol = kwargs['protocol']
@@ -96,7 +97,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             link0_parameters['%mem'] = '2048MB'
         else:
             # If memory is set, specify 80% of it to gaussian
-            link0_parameters['%mem'] = '%dMB' % ((0.8 * options['max_memory_kb']) // 1024)  # pylint: disable=consider-using-f-string)
+            link0_parameters['%mem'] = '%dMB' % ((0.8 * options['max_memory_kb']) // 1024)
 
         # Determine the number of processors that should be specified to Gaussian
         n_proc = None
@@ -180,7 +181,7 @@ class GaussianCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             'basis_set': sel_protocol['basis_set'],
             'charge': 0,
             'multiplicity': spin_multiplicity,
-            'route_parameters': route_params
+            'route_parameters': route_params,
         }
 
         builder = self.process_class.get_builder()

--- a/aiida_common_workflows/workflows/relax/gaussian/workchain.py
+++ b/aiida_common_workflows/workflows/relax/gaussian/workchain.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Gaussian."""
+import numpy as np
 from aiida import orm
 from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
-import numpy as np
 
 from ..workchain import CommonRelaxWorkChain
 from .generator import GaussianCommonRelaxInputGenerator

--- a/aiida_common_workflows/workflows/relax/generator.py
+++ b/aiida_common_workflows/workflows/relax/generator.py
@@ -28,7 +28,7 @@ class CommonRelaxInputGenerator(InputGenerator, ProtocolRegistry, metaclass=abc.
         spec.input(
             'structure',
             valid_type=plugins.DataFactory('core.structure'),
-            help='The structure whose geometry should be optimized.'
+            help='The structure whose geometry should be optimized.',
         )
         spec.input(
             'protocol',

--- a/aiida_common_workflows/workflows/relax/gpaw/__init__.py
+++ b/aiida_common_workflows/workflows/relax/gpaw/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for GPAW."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/gpaw/generator.py
+++ b/aiida_common_workflows/workflows/relax/gpaw/generator.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import pathlib
-from typing import Any, Dict, List, Tuple
+import typing as t
 
-from aiida import engine, orm, plugins
 import yaml
+from aiida import engine, orm, plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 
@@ -21,15 +21,17 @@ class GpawCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `GpawCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
-    _engine_types = {'relax': {'code_plugin': 'ase.ase', 'description': 'The code to perform the relaxation.'}}
-    _relax_types = {
+    _engine_types: t.ClassVar = {
+        'relax': {'code_plugin': 'ase.ase', 'description': 'The code to perform the relaxation.'}
+    }
+    _relax_types: t.ClassVar = {
         RelaxType.NONE: 'Do not perform relaxation.',
         RelaxType.POSITIONS: 'Relax only the atomic positions while keeping the cell fixed.',
     }
-    _spin_types = {
+    _spin_types: t.ClassVar = {
         SpinType.NONE: 'Treat the system without spin polarization.',
     }
-    _electronic_types = {
+    _electronic_types: t.ClassVar = {
         ElectronicType.METAL: 'Treat the system as a metal with smeared occupations.',
     }
 
@@ -43,20 +45,20 @@ class GpawCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         with open(str(pathlib.Path(__file__).parent / 'protocol.yml'), encoding='utf-8') as handle:
             self._protocols = yaml.safe_load(handle)
 
-    def _construct_builder( # pylint: disable=arguments-differ,too-many-locals
+    def _construct_builder(  # noqa: PLR0913
         self,
         structure: StructureData,
-        engines: Dict[str, Any],
+        engines: t.Dict[str, t.Any],
         *,
-        protocol: str = None,
+        protocol: t.Optional[str] = None,
         relax_type: RelaxType | str = RelaxType.POSITIONS,
         electronic_type: ElectronicType | str = ElectronicType.METAL,
         spin_type: SpinType | str = SpinType.NONE,
-        magnetization_per_site: List[float] | Tuple[float] | None = None,
-        threshold_forces: float = None,
-        threshold_stress: float = None,
+        magnetization_per_site: t.List[float] | t.Tuple[float] | None = None,
+        threshold_forces: t.Optional[float] = None,
+        threshold_stress: t.Optional[float] = None,
         reference_workchain=None,
-        **kwargs
+        **kwargs,
     ) -> engine.ProcessBuilder:
         """Return a process builder for the corresponding workchain class with inputs set according to the protocol.
 
@@ -77,7 +79,7 @@ class GpawCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         """
         protocol = protocol or self.get_default_protocol_name()
 
-        super().get_builder( # pylint: disable=too-many-function-args
+        super().get_builder(
             structure,
             engines,
             protocol=protocol,
@@ -88,7 +90,7 @@ class GpawCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             threshold_forces=threshold_forces,
             threshold_stress=threshold_stress,
             reference_workchain=reference_workchain,
-            **kwargs
+            **kwargs,
         )
 
         if isinstance(electronic_type, str):
@@ -105,9 +107,7 @@ class GpawCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         parameters = protocol['parameters']
         parameters['atoms_getters'] = [
             'temperature',
-            ['forces', {
-                'apply_constraint': True
-            }],
+            ['forces', {'apply_constraint': True}],
             ['masses', {}],
         ]
         if relax_type == RelaxType.NONE:

--- a/aiida_common_workflows/workflows/relax/nwchem/__init__.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for NWChem."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/nwchem/generator.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/generator.py
@@ -3,9 +3,9 @@
 import pathlib
 import warnings
 
-from aiida import engine, orm, plugins
 import numpy as np
 import yaml
+from aiida import engine, orm, plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators import ChoiceType, CodeType
@@ -48,12 +48,12 @@ class NwchemCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         spec.inputs['electronic_type'].valid_type = ChoiceType((ElectronicType.METAL, ElectronicType.INSULATOR))
         spec.inputs['engines']['relax']['code'].valid_type = CodeType('nwchem.nwchem')
 
-    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
+    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:  # noqa: PLR0912,PLR0915
         """Construct a process builder based on the provided keyword arguments.
 
         The keyword arguments will have been validated against the input generator specification.
         """
-        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+
         structure = kwargs['structure']
         engines = kwargs['engines']
         protocol = kwargs['protocol']
@@ -78,7 +78,7 @@ class NwchemCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         else:
             reciprocal_axes_lengths = np.linalg.norm(np.linalg.inv(structure.cell), axis=1)
             kpoints = np.ceil(reciprocal_axes_lengths / target_spacing).astype(int).tolist()
-            parameters['nwpw']['monkhorst-pack'] = '{} {} {}'.format(*kpoints)  # pylint: disable=consider-using-f-string
+            parameters['nwpw']['monkhorst-pack'] = '{} {} {}'.format(*kpoints)
 
         # Relaxation type
         if relax_type == RelaxType.POSITIONS:
@@ -95,7 +95,7 @@ class NwchemCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         else:
             raise ValueError(f'relax_type `{relax_type.value}` is not supported')
 
-        # Electronic type
+        # Electronic type
         if electronic_type == ElectronicType.INSULATOR:
             pass
         elif electronic_type == ElectronicType.METAL:

--- a/aiida_common_workflows/workflows/relax/nwchem/workchain.py
+++ b/aiida_common_workflows/workflows/relax/nwchem/workchain.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for NWChem."""
+import numpy as np
 from aiida import orm
 from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
-import numpy as np
 
 from ..workchain import CommonRelaxWorkChain
 from .generator import NwchemCommonRelaxInputGenerator

--- a/aiida_common_workflows/workflows/relax/orca/__init__.py
+++ b/aiida_common_workflows/workflows/relax/orca/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for Orca."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/orca/generator.py
+++ b/aiida_common_workflows/workflows/relax/orca/generator.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Orca."""
-from copy import deepcopy
 import os
 import warnings
+from copy import deepcopy
 
-from aiida import engine, orm
-from aiida.plugins import DataFactory
 import numpy as np
 import yaml
+from aiida import engine, orm
+from aiida.plugins import DataFactory
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators import ChoiceType, CodeType
@@ -34,8 +34,7 @@ class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         def raise_invalid(message):
             raise RuntimeError(f'invalid protocol registry `{self.__class__.__name__}`: ' + message)
 
-        for k, v in self._protocols.items():  # pylint: disable=invalid-name
-
+        for k, v in self._protocols.items():
             if 'input_keywords' not in v:
                 raise_invalid(f'protocol `{k}` does not define the mandatory key `input_keywords`')
 
@@ -58,12 +57,12 @@ class OrcaCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         spec.inputs['electronic_type'].valid_type = ChoiceType((ElectronicType.METAL, ElectronicType.INSULATOR))
         spec.inputs['engines']['relax']['code'].valid_type = CodeType('orca_main')
 
-    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
+    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:  # noqa: PLR0912,PLR0915
         """Construct a process builder based on the provided keyword arguments.
 
         The keyword arguments will have been validated against the input generator specification.
         """
-        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+
         structure = kwargs['structure']
         engines = kwargs['engines']
         protocol = kwargs['protocol']

--- a/aiida_common_workflows/workflows/relax/orca/workchain.py
+++ b/aiida_common_workflows/workflows/relax/orca/workchain.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Orca."""
+import numpy as np
 from aiida.engine import calcfunction
 from aiida.orm import ArrayData, Float
 from aiida.plugins import WorkflowFactory
-import numpy as np
 
 from ..workchain import CommonRelaxWorkChain
 from .generator import OrcaCommonRelaxInputGenerator
@@ -59,4 +59,4 @@ class OrcaCommonRelaxWorkChain(CommonRelaxWorkChain):
             self.out('total_magnetization', get_total_magnetization(self.ctx.workchain.outputs.output_parameters))
 
 
-#EOF
+# EOF

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/__init__.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable,cyclic-import
+
 """Module with the implementations of the common structure relaxation workchain for Quantum ESPRESSO."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/extractors.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/extractors.py
@@ -10,7 +10,7 @@ from .workchain import QuantumEspressoCommonRelaxWorkChain
 
 
 def get_ts_energy(common_relax_workchain: QuantumEspressoCommonRelaxWorkChain) -> float:
-    """ Return the T * S value of a concluded ``QuantumEspressoCommonRelaxWorkChain``.
+    """Return the T * S value of a concluded ``QuantumEspressoCommonRelaxWorkChain``.
 
     Here, T is the fictitious temperature due to the use of smearing and S is the entropy. This "smearing contribution"
     to the free energy in Quantum ESPRESSO is expressed as -T * S:

--- a/aiida_common_workflows/workflows/relax/quantum_espresso/workchain.py
+++ b/aiida_common_workflows/workflows/relax/quantum_espresso/workchain.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.workchain.CommonRelaxWorkChain` for Quantum ESPRESSO."""
+import pint
 from aiida import orm
 from aiida.engine import calcfunction
 from aiida.plugins import WorkflowFactory
-import pint
 
 from ..workchain import CommonRelaxWorkChain
 from .generator import QuantumEspressoCommonRelaxInputGenerator
@@ -55,9 +55,9 @@ class QuantumEspressoCommonRelaxWorkChain(CommonRelaxWorkChain):
         forces, stress = extract_from_trajectory(outputs.output_trajectory).values()
 
         try:
-            total_energy, total_magnetization = result  # pylint: disable=unbalanced-dict-unpacking
+            total_energy, total_magnetization = result
         except ValueError:
-            total_energy, total_magnetization = list(result)[0], None
+            total_energy, total_magnetization = next(iter(result)), None
 
         if 'output_structure' in outputs:
             self.out('relaxed_structure', outputs.output_structure)

--- a/aiida_common_workflows/workflows/relax/siesta/__init__.py
+++ b/aiida_common_workflows/workflows/relax/siesta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for Siesta."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/siesta/extractors.py
+++ b/aiida_common_workflows/workflows/relax/siesta/extractors.py
@@ -26,6 +26,6 @@ def get_ts_energy(common_relax_workchain):
     e_ks = siesta_base_wc.outputs.output_parameters['E_KS']
     free_e = siesta_base_wc.outputs.output_parameters['FreeE']
 
-    ts = e_ks - free_e  #pylint: disable=invalid-name
+    ts = e_ks - free_e
 
     return ts

--- a/aiida_common_workflows/workflows/relax/vasp/__init__.py
+++ b/aiida_common_workflows/workflows/relax/vasp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable,cyclic-import
+
 """Module with the implementations of the common structure relaxation workchain for VASP."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/vasp/generator.py
+++ b/aiida_common_workflows/workflows/relax/vasp/generator.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for VASP."""
 import pathlib
+import typing as t
 
+import yaml
 from aiida import engine, plugins
 from aiida.common.extendeddicts import AttributeDict
-import yaml
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators import ChoiceType, CodeType
@@ -20,19 +21,11 @@ class VaspCommonRelaxInputGenerator(CommonRelaxInputGenerator):
     """Input generator for the `VaspCommonRelaxWorkChain`."""
 
     _default_protocol = 'moderate'
-    _protocols = {
-        'fast': {
-            'description': 'Fast and not so accurate.'
-        },
-        'moderate': {
-            'description': 'Possibly a good compromise for quick checks.'
-        },
-        'precise': {
-            'description': 'Decent level of accuracy with some exceptions.'
-        },
-        'verification-PBE-v1': {
-            'description': 'Used for the ACWF study on unaries and oxides.'
-        }
+    _protocols: t.ClassVar = {
+        'fast': {'description': 'Fast and not so accurate.'},
+        'moderate': {'description': 'Possibly a good compromise for quick checks.'},
+        'precise': {'description': 'Decent level of accuracy with some exceptions.'},
+        'verification-PBE-v1': {'description': 'Used for the ACWF study on unaries and oxides.'},
     }
 
     def __init__(self, *args, **kwargs):
@@ -64,12 +57,12 @@ class VaspCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         spec.inputs['engines']['relax']['code'].valid_type = CodeType('vasp.vasp')
         spec.inputs['protocol'].valid_type = ChoiceType(('fast', 'moderate', 'precise', 'verification-PBE-v1'))
 
-    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
+    def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:  # noqa: PLR0912,PLR0915
         """Construct a process builder based on the provided keyword arguments.
 
         The keyword arguments will have been validated against the input generator specification.
         """
-        # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+
         structure = kwargs['structure']
         engines = kwargs['engines']
         protocol = kwargs['protocol']
@@ -120,68 +113,62 @@ class VaspCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         # Set settings
         # Make sure the VASP parser is configured for the problem
         settings = AttributeDict()
-        settings.update({
-            'parser_settings': {
-                'critical_notifications': {
-                    'add_brmix': True,
-                    'add_cnormn': False,
-                    'add_denmp': True,
-                    'add_dentet': True,
-                    'add_edddav_zhegv': True,
-                    'add_eddrmm_zhegv': True,
-                    'add_edwav': True,
-                    'add_fexcp': True,
-                    'add_fock_acc': True,
-                    'add_non_collinear': True,
-                    'add_not_hermitian': True,
-                    'add_pzstein': True,
-                    'add_real_optlay': True,
-                    'add_rhosyg': True,
-                    'add_rspher': True,
-                    'add_set_indpw_full': True,
-                    'add_sgrcon': True,
-                    'add_no_potimm': True,
-                    'add_magmom': True,
-                    'add_bandocc': True
-                },
-                'add_energies': True,
-                'add_forces': True,
-                'add_stress': True,
-                'add_misc': {
-                    'type':
-                    'dict',
-                    'quantities': [
-                        'total_energies', 'maximum_stress', 'maximum_force', 'magnetization', 'notifications',
-                        'run_status', 'run_stats', 'version'
-                    ],
-                    'link_name':
-                    'misc'
-                },
-                'energy_type': ['energy_free', 'energy_no_entropy']
+        settings.update(
+            {
+                'parser_settings': {
+                    'critical_notifications': {
+                        'add_brmix': True,
+                        'add_cnormn': False,
+                        'add_denmp': True,
+                        'add_dentet': True,
+                        'add_edddav_zhegv': True,
+                        'add_eddrmm_zhegv': True,
+                        'add_edwav': True,
+                        'add_fexcp': True,
+                        'add_fock_acc': True,
+                        'add_non_collinear': True,
+                        'add_not_hermitian': True,
+                        'add_pzstein': True,
+                        'add_real_optlay': True,
+                        'add_rhosyg': True,
+                        'add_rspher': True,
+                        'add_set_indpw_full': True,
+                        'add_sgrcon': True,
+                        'add_no_potimm': True,
+                        'add_magmom': True,
+                        'add_bandocc': True,
+                    },
+                    'add_energies': True,
+                    'add_forces': True,
+                    'add_stress': True,
+                    'add_misc': {
+                        'type': 'dict',
+                        'quantities': [
+                            'total_energies',
+                            'maximum_stress',
+                            'maximum_force',
+                            'magnetization',
+                            'notifications',
+                            'run_status',
+                            'run_stats',
+                            'version',
+                        ],
+                        'link_name': 'misc',
+                    },
+                    'energy_type': ['energy_free', 'energy_no_entropy'],
+                }
             }
-        })
+        )
         builder.settings = plugins.DataFactory('core.dict')(dict=settings)
 
         # Configure the handlers
         handler_overrides = {
-            'handler_unfinished_calc_ionic_alt': {
-                'enabled': True
-            },
-            'handler_unfinished_calc_generic_alt': {
-                'enabled': True
-            },
-            'handler_electronic_conv_alt': {
-                'enabled': True
-            },
-            'handler_unfinished_calc_ionic': {
-                'enabled': False
-            },
-            'handler_unfinished_calc_generic': {
-                'enabled': False
-            },
-            'handler_electronic_conv': {
-                'enabled': False
-            }
+            'handler_unfinished_calc_ionic_alt': {'enabled': True},
+            'handler_unfinished_calc_generic_alt': {'enabled': True},
+            'handler_electronic_conv_alt': {'enabled': True},
+            'handler_unfinished_calc_ionic': {'enabled': False},
+            'handler_unfinished_calc_generic': {'enabled': False},
+            'handler_electronic_conv': {'enabled': False},
         }
         builder.handler_overrides = plugins.DataFactory('core.dict')(dict=handler_overrides)
 

--- a/aiida_common_workflows/workflows/relax/wien2k/__init__.py
+++ b/aiida_common_workflows/workflows/relax/wien2k/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=undefined-variable
+
 """Module with the implementations of the common structure relaxation workchain for Wien2k."""
 from .generator import *
 from .workchain import *

--- a/aiida_common_workflows/workflows/relax/wien2k/generator.py
+++ b/aiida_common_workflows/workflows/relax/wien2k/generator.py
@@ -2,8 +2,8 @@
 """Implementation of `aiida_common_workflows.common.relax.generator.CommonRelaxInputGenerator` for Wien2k."""
 import os
 
-from aiida import engine, orm, plugins
 import yaml
+from aiida import engine, orm, plugins
 
 from aiida_common_workflows.common import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators import ChoiceType, CodeType
@@ -60,6 +60,7 @@ class Wien2kCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         # Checks
         if protocol not in self.get_protocol_names():
             import warnings
+
             warnings.warn(f'no protocol implemented with name {protocol}, using default moderate')
             protocol = self.get_default_protocol_name()
         if not all(x in engines.keys() for x in ['relax']):
@@ -94,11 +95,13 @@ class Wien2kCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             # derive k mesh from the ref. workchain and pass as input
             if 'kmesh3' in ref_wrkchn_res_dict and ref_wrkchn_res_dict['kmesh3']:  # check if kmesh3 is in results dict
                 inpdict['-numk'] = '0' + ' ' + ref_wrkchn_res_dict['kmesh3']
-            if 'kmesh3k' in ref_wrkchn_res_dict and ref_wrkchn_res_dict['kmesh3k'
-                                                                        ]:  # check if kmesh3k is in results dict
+            if (
+                'kmesh3k' in ref_wrkchn_res_dict and ref_wrkchn_res_dict['kmesh3k']
+            ):  # check if kmesh3k is in results dict
                 inpdict['-numk2'] = '0' + ' ' + ref_wrkchn_res_dict['kmesh3k']
-            if 'fftmesh3k' in ref_wrkchn_res_dict and ref_wrkchn_res_dict['fftmesh3k'
-                                                                          ]:  # check if fftmesh3k is in results dict
+            if (
+                'fftmesh3k' in ref_wrkchn_res_dict and ref_wrkchn_res_dict['fftmesh3k']
+            ):  # check if fftmesh3k is in results dict
                 inpdict['-fft'] = ref_wrkchn_res_dict['fftmesh3k']
 
         # res = NodeNumberJobResource(num_machines=8, num_mpiprocs_per_machine=1, num_cores_per_mpiproc=1)

--- a/aiida_common_workflows/workflows/relax/workchain.py
+++ b/aiida_common_workflows/workflows/relax/workchain.py
@@ -27,7 +27,7 @@ class CommonRelaxWorkChain(WorkChain, metaclass=ABCMeta):
 
         :return: input generator
         """
-        return cls._generator_class(process_class=cls)  # pylint: disable=not-callable
+        return cls._generator_class(process_class=cls)
 
     @classmethod
     def define(cls, spec):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=missing-module-docstring,redefined-builtin,invalid-name
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ docs = [
 ]
 pre-commit = [
     'pre-commit~=2.2',
-    'pylint~=2.16.0',
 ]
 tests = [
     'pytest~=7.2',
@@ -105,33 +104,29 @@ exclude = [
 line-length = 120
 fail-on-change = true
 
-[tool.isort]
-force_sort_within_sections = true
-include_trailing_comma = true
-line_length = 120
-multi_line_output = 3
-
-[tool.pydocstyle]
+[tool.ruff]
 ignore = [
-    'D104',
-    'D202',
-    'D203',
-    'D213'
+    'PLR2004',  # Magic value used in comparison
+    'PLE0604',  # Invalid object in `__all__`, must contain only strings
+    'F403',  # Star imports unable to detect undefined names
+    'F405',  # Import may be undefined or defined from star imports
+]
+line-length = 120
+select = [
+    'E',  # pydocstyle
+    'W',  # pydocstyle
+    'F',  # pyflakes
+    'I',  # isort
+    'N',  # pep8-naming
+    'PLC',
+    'PLE',
+    'PLR',
+    'PLW',
+    'RUF'  # ruff
 ]
 
-[tool.pylint.format]
-max-line-length = 120
-
-[tool.pylint.messages_control]
-disable = [
-    'import-outside-toplevel',
-    'inconsistent-return-statements',
-    'too-many-arguments',
-    'duplicate-code',
-    'no-member',
-    'too-few-public-methods',
-    'wrong-import-order'
-]
+[tool.ruff.format]
+quote-style = 'single'
 
 [tool.pytest.ini_options]
 testpaths = [
@@ -151,12 +146,3 @@ filterwarnings = [
     'ignore:Creating AiiDA configuration folder.*:UserWarning',
     'ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning',
 ]
-
-[tool.yapf]
-align_closing_bracket_with_visual_indent = true
-based_on_style = 'google'
-coalesce_brackets = true
-column_limit = 120
-dedent_closing_brackets = true
-indent_dictionary_value = false
-split_arguments_when_comma_terminated = true

--- a/tests/cli/test_launch.py
+++ b/tests/cli/test_launch.py
@@ -27,8 +27,10 @@ def test_relax_wallclock_seconds(run_cli_command, generate_structure, generate_c
     # Passing two values for `-w` should raise as only one value is required
     options = ['-S', str(structure.pk), '-w', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_relax, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
-           'requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so '
+        'requires 1 values' in result.output_lines
+    )
 
 
 def test_relax_number_machines(run_cli_command, generate_structure, generate_code):
@@ -39,8 +41,10 @@ def test_relax_number_machines(run_cli_command, generate_structure, generate_cod
     # Passing two values for `-m` should raise as only one value is required
     options = ['-S', str(structure.pk), '-m', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_relax, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
-           'requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so '
+        'requires 1 values' in result.output_lines
+    )
 
 
 def test_relax_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
@@ -53,8 +57,10 @@ def test_relax_number_mpi_procs_per_machine(run_cli_command, generate_structure,
     # Passing two values for `-n` should raise as only one value is required
     options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_relax, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '\
-           'steps, so requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '
+        'steps, so requires 1 values' in result.output_lines
+    )
 
 
 @pytest.mark.usefixtures('with_clean_database')
@@ -103,8 +109,10 @@ def test_eos_wallclock_seconds(run_cli_command, generate_structure, generate_cod
     # Passing two values for `-w` should raise as only one value is required
     options = ['-S', str(structure.pk), '-w', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
-           'requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so '
+        'requires 1 values' in result.output_lines
+    )
 
 
 def test_eos_number_machines(run_cli_command, generate_structure, generate_code):
@@ -115,8 +123,10 @@ def test_eos_number_machines(run_cli_command, generate_structure, generate_code)
     # Passing two values for `-m` should raise as only one value is required
     options = ['-S', str(structure.pk), '-m', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
-           'requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so '
+        'requires 1 values' in result.output_lines
+    )
 
 
 def test_eos_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
@@ -129,8 +139,10 @@ def test_eos_number_mpi_procs_per_machine(run_cli_command, generate_structure, g
     # Passing two values for `-n` should raise as only one value is required
     options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_eos, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '\
-           'steps, so requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '
+        'steps, so requires 1 values' in result.output_lines
+    )
 
 
 def test_eos_relax_types(run_cli_command, generate_structure, generate_code):
@@ -152,8 +164,10 @@ def test_dissociation_curve_wallclock_seconds(run_cli_command, generate_structur
     # Passing two values for `-w` should raise as only one value is required
     options = ['-S', str(structure.pk), '-w', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_dissociation_curve, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
-           'requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --wallclock-seconds: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so '
+        'requires 1 values' in result.output_lines
+    )
 
 
 @pytest.mark.usefixtures('aiida_profile')
@@ -175,8 +189,10 @@ def test_dissociation_curve_number_machines(run_cli_command, generate_structure,
     # Passing two values for `-m` should raise as only one value is required
     options = ['-S', str(structure.pk), '-m', '100', '100', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_dissociation_curve, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so ' \
-           'requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --number-machines: QuantumEspressoCommonRelaxWorkChain has 1 engine steps, so '
+        'requires 1 values' in result.output_lines
+    )
 
 
 def test_dissociation_curve_number_mpi_procs_per_machine(run_cli_command, generate_structure, generate_code):
@@ -189,8 +205,10 @@ def test_dissociation_curve_number_mpi_procs_per_machine(run_cli_command, genera
     # Passing two values for `-n` should raise as only one value is required
     options = ['-S', str(structure.pk), '-n', '10', '10', '--', 'quantum_espresso']
     result = run_cli_command(launch.cmd_dissociation_curve, options, raises=click.BadParameter)
-    assert 'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '\
-           'steps, so requires 1 values' in result.output_lines
+    assert (
+        'Error: Invalid value for --number-mpi-procs-per-machine: QuantumEspressoCommonRelaxWorkChain has 1 engine '
+        'steps, so requires 1 values' in result.output_lines
+    )
 
 
 def test_relax_magn_per_type(run_cli_command, generate_structure, generate_code):

--- a/tests/cli/test_options.py
+++ b/tests/cli/test_options.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
+
 """Tests for the :mod:`aiida_common_workflows.cli.launch` module."""
 import json
 import pathlib
 
-from aiida import orm
 import click
 import pytest
+from aiida import orm
 
 from aiida_common_workflows.cli import options
 
@@ -69,14 +69,15 @@ class TestStructureDataParamType:
         assert result.uuid == structure.uuid
 
     @pytest.mark.parametrize(
-        'label, formula', (
+        'label, formula',
+        (
             ('Al', 'Al4'),
             ('Fe', 'Fe2'),
             ('GeTe', 'GeTe'),
             ('Si', 'Si2'),
             ('NH3-pyramidal', 'H3N'),
             ('NH3-planar', 'H3N'),
-        )
+        ),
     )
     def test_parse_predefined_defaults(self, structure_param_type, label, formula):
         """Test the shortcut labels.

--- a/tests/cli/test_plot.py
+++ b/tests/cli/test_plot.py
@@ -96,7 +96,7 @@ def test_plot_eos_missing_outputs(run_cli_command, generate_eos_node):
 
     options = [str(node.pk)]
     result = run_cli_command(plot.cmd_plot_eos, options, raises=SystemExit)
-    assert 'is missing required outputs: (\'total_energies\',)' in result.output
+    assert "is missing required outputs: ('total_energies',)" in result.output
 
 
 def test_plot_dissociation_curve(run_cli_command, generate_dissociation_curve_node, monkeypatch):
@@ -178,4 +178,4 @@ def test_plot_dissociation_curve_missing_outputs(run_cli_command, generate_disso
 
     options = [str(node.pk)]
     result = run_cli_command(plot.cmd_plot_dissociation_curve, options, raises=SystemExit)
-    assert 'is missing required outputs: (\'total_energies\',)' in result.output
+    assert "is missing required outputs: ('total_energies',)" in result.output

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.generators.generator` module."""
+import pytest
 from aiida import orm
 from aiida.plugins import WorkflowFactory
-import pytest
 
 from aiida_common_workflows.generators import InputGenerator
 
@@ -92,8 +92,7 @@ def test_get_builder_mutable_kwargs(generate_input_generator_cls, monkeypatch):
 
 
 def test_get_builder_immutable_kwargs_nested(generate_input_generator_cls, generate_structure):
-    """Test that calling ``get_builder`` does not mutate the ``kwargs`` when they are nodes, even if nested.
-    """
+    """Test that calling ``get_builder`` does not mutate the ``kwargs`` when they are nodes, even if nested."""
     cls = generate_input_generator_cls(inputs_dict={'space.structure': orm.StructureData})
     generator = cls(process_class=WorkflowFactory('common_workflows.relax.siesta'))
 

--- a/tests/protocol/test_registry.py
+++ b/tests/protocol/test_registry.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=function-redefined,redefined-outer-name
 """Tests for the :mod:`aiida_common_workflows.protocol.registry` module."""
+import typing as t
+
 import pytest
 
 from aiida_common_workflows.protocol import ProtocolRegistry
@@ -13,7 +14,10 @@ def protocol_registry() -> ProtocolRegistry:
     class SubProtocolRegistry(ProtocolRegistry):
         """Valid protocol registry implementation."""
 
-        _protocols = {'efficiency': {'description': 'description'}, 'precision': {'description': 'description'}}
+        _protocols: t.ClassVar = {
+            'efficiency': {'description': 'description'},
+            'precision': {'description': 'description'},
+        }
         _default_protocol = 'efficiency'
 
     return SubProtocolRegistry()
@@ -34,7 +38,7 @@ def test_validation():
     class SubProtocolRegistry(ProtocolRegistry):
         """Invalid protocol registry implementation."""
 
-        _protocols = {'efficiency': {}, 'precision': 'wrong_type'}
+        _protocols: t.ClassVar = {'efficiency': {}, 'precision': 'wrong_type'}
         _default_protocol = None
 
     with pytest.raises(RuntimeError):
@@ -43,7 +47,7 @@ def test_validation():
     class SubProtocolRegistry(ProtocolRegistry):
         """Invalid protocol registry implementation."""
 
-        _protocols = {'efficiency': {'description': 'description'}, 'precision': {}}
+        _protocols: t.ClassVar = {'efficiency': {'description': 'description'}, 'precision': {}}
         _default_protocol = None
 
     with pytest.raises(RuntimeError):
@@ -52,7 +56,10 @@ def test_validation():
     class SubProtocolRegistry(ProtocolRegistry):
         """Invalid protocol registry implementation."""
 
-        _protocols = {'efficiency': {'description': 'description'}, 'precision': {'description': 'description'}}
+        _protocols: t.ClassVar = {
+            'efficiency': {'description': 'description'},
+            'precision': {'description': 'description'},
+        }
         _default_protocol = None
 
     with pytest.raises(RuntimeError):
@@ -61,7 +68,10 @@ def test_validation():
     class SubProtocolRegistry(ProtocolRegistry):
         """Invalid protocol registry implementation."""
 
-        _protocols = {'efficiency': {'description': 'description'}, 'precision': {'description': 'description'}}
+        _protocols: t.ClassVar = {
+            'efficiency': {'description': 'description'},
+            'precision': {'description': 'description'},
+        }
         _default_protocol = 'non-existant'
 
     with pytest.raises(RuntimeError):

--- a/tests/workflows/bands/test_implementations.py
+++ b/tests/workflows/bands/test_implementations.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, orm, plugins
+
 import pytest
+from aiida import engine, orm, plugins
 
 from aiida_common_workflows.generators.ports import InputGeneratorPort
 from aiida_common_workflows.plugins import get_workflow_entry_point_names
@@ -21,12 +21,8 @@ def test_spec(workchain):
     generator_spec = generator.spec()
 
     required_ports = {
-        'bands_kpoints': {
-            'valid_type': plugins.DataFactory('core.array.kpoints')
-        },
-        'parent_folder': {
-            'valid_type': orm.RemoteData
-        },
+        'bands_kpoints': {'valid_type': plugins.DataFactory('core.array.kpoints')},
+        'parent_folder': {'valid_type': orm.RemoteData},
         'engines': {},
     }
 

--- a/tests/workflows/bands/test_workchain.py
+++ b/tests/workflows/bands/test_workchain.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=abstract-method,arguments-differ,redefined-outer-name
+
 """Tests for the :mod:`aiida_common_workflows.workflows.bands.workchain` module."""
-from aiida.plugins import WorkflowFactory
 import pytest
+from aiida.plugins import WorkflowFactory
 
 from aiida_common_workflows.plugins import get_workflow_entry_point_names
 from aiida_common_workflows.workflows.bands import CommonBandsInputGenerator

--- a/tests/workflows/dissociation_curve/test_workchain_diss_curve.py
+++ b/tests/workflows/dissociation_curve/test_workchain_diss_curve.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
+
 """Tests for the :mod:`aiida_common_workflows.workflows.dissociation` module."""
 import copy
 
+import pytest
 from aiida import orm
 from aiida.engine import WorkChain
 from aiida.plugins import WorkflowFactory
-import pytest
 
 from aiida_common_workflows.plugins import get_workflow_entry_point_names
 from aiida_common_workflows.workflows import dissociation
@@ -35,9 +35,11 @@ def test_validate_sub_process_class(ctx):
 def test_validate_sub_process_class_plugins(ctx, common_relax_workchain):
     """Test the `validate_sub_process_class` validator."""
     from aiida_common_workflows.plugins import get_entry_point_name_from_class
-    assert dissociation.validate_sub_process_class(
-        get_entry_point_name_from_class(common_relax_workchain).name, ctx
-    ) is None
+
+    assert (
+        dissociation.validate_sub_process_class(get_entry_point_name_from_class(common_relax_workchain).name, ctx)
+        is None
+    )
 
 
 @pytest.mark.usefixtures('sssp')
@@ -48,41 +50,38 @@ def test_validate_inputs_distance(ctx, generate_code, generate_structure):
         'sub_process_class': 'common_workflows.relax.quantum_espresso',
         'generator_inputs': {
             'engines': {
-                'relax': {
-                    'code': generate_code('quantumespresso.pw'),
-                    'options': {
-                        'resources': {
-                            'num_machines': 1
-                        }
-                    }
-                }
+                'relax': {'code': generate_code('quantumespresso.pw'), 'options': {'resources': {'num_machines': 1}}}
             },
-            'spin_type': 'collinear'
-        }
+            'spin_type': 'collinear',
+        },
     }
 
     value = copy.deepcopy(base_values)
-    assert dissociation.validate_inputs(
-        value, ctx
-    ) == 'neither `distances` nor the `distances_count`, `distance_min`, and `distance_max` set were defined.'
+    assert (
+        dissociation.validate_inputs(value, ctx)
+        == 'neither `distances` nor the `distances_count`, `distance_min`, and `distance_max` set were defined.'
+    )
 
     value = copy.deepcopy(base_values)
     value.update({'distances_count': 3, 'distance_min': 0.5})
-    assert dissociation.validate_inputs(
-        value, ctx
-    ) == 'neither `distances` nor the `distances_count`, `distance_min`, and `distance_max` set were defined.'
+    assert (
+        dissociation.validate_inputs(value, ctx)
+        == 'neither `distances` nor the `distances_count`, `distance_min`, and `distance_max` set were defined.'
+    )
 
     value = copy.deepcopy(base_values)
     value.update({'distances_count': 3, 'distance_max': 1.5})
-    assert dissociation.validate_inputs(
-        value, ctx
-    ) == 'neither `distances` nor the `distances_count`, `distance_min`, and `distance_max` set were defined.'
+    assert (
+        dissociation.validate_inputs(value, ctx)
+        == 'neither `distances` nor the `distances_count`, `distance_min`, and `distance_max` set were defined.'
+    )
 
     value = copy.deepcopy(base_values)
     value.update({'distance_max': 2, 'distance_min': 0.5})
-    assert dissociation.validate_inputs(
-        value, ctx
-    ) == 'neither `distances` nor the `distances_count`, `distance_min`, and `distance_max` set were defined.'
+    assert (
+        dissociation.validate_inputs(value, ctx)
+        == 'neither `distances` nor the `distances_count`, `distance_min`, and `distance_max` set were defined.'
+    )
 
     value = copy.deepcopy(base_values)
     value.update({'distance_max': 2, 'distance_min': 0.5, 'distances_count': 3})
@@ -110,17 +109,10 @@ def test_validate_inputs_generator_inputs(ctx, generate_code, generate_structure
         'sub_process_class': 'common_workflows.relax.quantum_espresso',
         'generator_inputs': {
             'engines': {
-                'relax': {
-                    'code': generate_code('quantumespresso.pw'),
-                    'options': {
-                        'resources': {
-                            'num_machines': 1
-                        }
-                    }
-                }
+                'relax': {'code': generate_code('quantumespresso.pw'), 'options': {'resources': {'num_machines': 1}}}
             },
-            'spin_type': 'collinear'
-        }
+            'spin_type': 'collinear',
+        },
     }
 
     assert dissociation.validate_inputs(value, ctx) is None

--- a/tests/workflows/eos/test_workchain_eos.py
+++ b/tests/workflows/eos/test_workchain_eos.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
+
 """Tests for the :mod:`aiida_common_workflows.workflows.eos` module."""
 import copy
 
+import pytest
 from aiida import orm
 from aiida.engine import WorkChain
 from aiida.plugins import WorkflowFactory
-import pytest
 
 from aiida_common_workflows.plugins import get_workflow_entry_point_names
 from aiida_common_workflows.workflows import eos
@@ -40,16 +40,12 @@ def generate_eos_inputs(generate_structure, generate_code):
                 'engines': {
                     'relax': {
                         'code': generate_code('quantumespresso.pw').store(),
-                        'options': {
-                            'resources': {
-                                'num_machines': 1
-                            }
-                        }
+                        'options': {'resources': {'num_machines': 1}},
                     }
                 },
                 'electronic_type': 'metal',
-                'relax_type': 'positions'
-            }
+                'relax_type': 'positions',
+            },
         }
 
     return _generate_eos_inputs
@@ -65,6 +61,7 @@ def test_validate_sub_process_class(ctx):
 def test_validate_sub_process_class_plugins(ctx, common_relax_workchain):
     """Test the `validate_sub_process_class` validator."""
     from aiida_common_workflows.plugins import get_entry_point_name_from_class
+
     assert eos.validate_sub_process_class(get_entry_point_name_from_class(common_relax_workchain).name, ctx) is None
 
 
@@ -74,21 +71,24 @@ def test_validate_inputs_scale(ctx, generate_eos_inputs):
     base_values = generate_eos_inputs()
 
     value = copy.deepcopy(base_values)
-    assert eos.validate_inputs(
-        value, ctx
-    ) == 'neither `scale_factors` nor the pair of `scale_count` and `scale_increment` were defined.'
+    assert (
+        eos.validate_inputs(value, ctx)
+        == 'neither `scale_factors` nor the pair of `scale_count` and `scale_increment` were defined.'
+    )
 
     value = copy.deepcopy(base_values)
     value.update({'scale_count': 2})
-    assert eos.validate_inputs(
-        value, ctx
-    ) == 'neither `scale_factors` nor the pair of `scale_count` and `scale_increment` were defined.'
+    assert (
+        eos.validate_inputs(value, ctx)
+        == 'neither `scale_factors` nor the pair of `scale_count` and `scale_increment` were defined.'
+    )
 
     value = copy.deepcopy(base_values)
     value.update({'scale_increment': 2})
-    assert eos.validate_inputs(
-        value, ctx
-    ) == 'neither `scale_factors` nor the pair of `scale_count` and `scale_increment` were defined.'
+    assert (
+        eos.validate_inputs(value, ctx)
+        == 'neither `scale_factors` nor the pair of `scale_count` and `scale_increment` were defined.'
+    )
 
     value = copy.deepcopy(base_values)
     value.update({'scale_count': 2, 'scale_increment': 0.2})
@@ -137,21 +137,18 @@ def test_validate_scale_increment(ctx):
 def test_validate_relax_type(ctx):
     """Test the `validate_relax_type` validator."""
     assert eos.validate_relax_type(RelaxType.NONE, ctx) is None
-    assert eos.validate_relax_type(
-        RelaxType.CELL, ctx
-    ) == '`generator_inputs.relax_type`. Equation of state and relaxation with variable volume not compatible.'
+    assert (
+        eos.validate_relax_type(RelaxType.CELL, ctx)
+        == '`generator_inputs.relax_type`. Equation of state and relaxation with variable volume not compatible.'
+    )
 
 
 @pytest.mark.parametrize(
-    'scaling_inputs, expected', (
-        ({
-            'scale_factors': [0.98, 1.0, 1.02]
-        }, (0.98, 1.0, 1.02)),
-        ({
-            'scale_count': 3,
-            'scale_increment': 0.02
-        }, (0.98, 1.0, 1.02)),
-    )
+    'scaling_inputs, expected',
+    (
+        ({'scale_factors': [0.98, 1.0, 1.02]}, (0.98, 1.0, 1.02)),
+        ({'scale_count': 3, 'scale_increment': 0.02}, (0.98, 1.0, 1.02)),
+    ),
 )
 @pytest.mark.usefixtures('sssp')
 def test_get_scale_factors(generate_workchain, generate_eos_inputs, scaling_inputs, expected):

--- a/tests/workflows/relax/test_abinit.py
+++ b/tests/workflows/relax/test_abinit.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.abinit` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.abinit')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,12 +16,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('abinit').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }

--- a/tests/workflows/relax/test_bigdft.py
+++ b/tests/workflows/relax/test_bigdft.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.bigdft` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.bigdft')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,12 +16,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('bigdft').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }

--- a/tests/workflows/relax/test_castep.py
+++ b/tests/workflows/relax/test_castep.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.castep` module."""
-# pylint: disable=abstract-method,arguments-differ,redefined-outer-name,unused-argument
+
 import copy
 
+import pytest
 from aiida import engine, plugins
 from aiida.orm import StructureData
 from aiida.plugins import WorkflowFactory
 from aiida_castep.data.otfg import OTFGGroup
 from ase.build.bulk import bulk
-import pytest
 
 from aiida_common_workflows.workflows.relax.castep.generator import (
     CastepCommonRelaxInputGenerator,
@@ -28,14 +28,14 @@ GENERATOR = WORKCHAIN.get_input_generator()
 
 
 @pytest.fixture
-def nacl(with_database):  # pylint: disable=invalid-name
+def nacl(with_database):
     """Get an NaCl structure"""
     structure = StructureData(ase=bulk('NaCl', 'rocksalt', 4.2))
     return structure
 
 
 @pytest.fixture
-def si(with_database):  # pylint: disable=invalid-name
+def si(with_database):
     """Get an NaCl structure"""
     structure = StructureData(ase=bulk('Si', 'diamond', 5.43))
     return structure
@@ -61,15 +61,7 @@ def default_builder_inputs(generate_code, generate_structure, castep_code):
     return {
         'structure': generate_structure(symbols=('Si',)),
         'engines': {
-            'relax': {
-                'code': castep_code,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
-            }
+            'relax': {'code': castep_code, 'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}}}
         },
     }
 
@@ -124,12 +116,7 @@ def test_calc_generator(nacl, castep_code, with_otfg):
     """Test the functionality of the calculation generator"""
     protcol = {
         'kpoints_spacing': 0.05,
-        'calc': {
-            'parameters': {
-                'task': 'geometryoptimisation',
-                'basis_precision': 'medium'
-            }
-        }
+        'calc': {'parameters': {'task': 'geometryoptimisation', 'basis_precision': 'medium'}},
     }
     override = {'calc': {'parameters': {'cut_off_energy': 220}}}
     otfg = OTFGGroup.collection.get(label='C19')
@@ -146,12 +133,7 @@ def test_base_generator(castep_code, nacl, with_otfg):
     protcol = {
         'kpoints_spacing': 0.05,
         'max_iterations': 5,
-        'calc': {
-            'parameters': {
-                'task': 'geometryoptimisation',
-                'basis_precision': 'medium'
-            }
-        }
+        'calc': {'parameters': {'task': 'geometryoptimisation', 'basis_precision': 'medium'}},
     }
     override = {'calc': {'parameters': {'cut_off_energy': 220}, 'metadata': {'label': 'test'}}}
     otfg = OTFGGroup.collection.get(label='C19')
@@ -167,22 +149,14 @@ def test_base_generator(castep_code, nacl, with_otfg):
 
 def test_relax_generator(castep_code, nacl, with_otfg):
     """Test for generating the relax namespace"""
-    CastepCommonRelaxWorkChain = WorkflowFactory('castep.relax')  # pylint: disable=invalid-name
-    protocol = CastepCommonRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain
-                                               ).get_protocol('moderate')['relax']
+    CastepCommonRelaxWorkChain = WorkflowFactory('castep.relax')  # noqa: N806
+    protocol = CastepCommonRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain).get_protocol('moderate')[
+        'relax'
+    ]
     override = {
         'base': {
-            'metadata': {
-                'label': 'test'
-            },
-            'calc': {
-                'parameters': {
-                    'cut_off_energy': 220
-                },
-                'metadata': {
-                    'label': 'test'
-                }
-            }
+            'metadata': {'label': 'test'},
+            'calc': {'parameters': {'cut_off_energy': 220}, 'metadata': {'label': 'test'}},
         }
     }
     otfg = OTFGGroup.collection.get(label='C19')
@@ -198,7 +172,7 @@ def test_relax_generator(castep_code, nacl, with_otfg):
     assert generated['base']['metadata']['label'] == 'test'
 
 
-def test_generate_inputs(castep_code, nacl, si):  # pylint: disable=invalid-name
+def test_generate_inputs(castep_code, nacl, si):
     """
     Test for the generator
     """
@@ -214,7 +188,7 @@ def test_generate_inputs(castep_code, nacl, si):  # pylint: disable=invalid-name
     assert 'structure' in output['calc']
 
 
-def test_input_generator(castep_code, nacl, si):  # pylint: disable=invalid-name
+def test_input_generator(castep_code, nacl, si):
     """Test for the input generator"""
     gen = CastepCommonRelaxInputGenerator(process_class=CastepCommonRelaxWorkChain)
     engines = {'relax': {'code': castep_code, 'options': {}}}

--- a/tests/workflows/relax/test_cp2k.py
+++ b/tests/workflows/relax/test_cp2k.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.cp2k` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.cp2k')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,12 +16,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('cp2k').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }

--- a/tests/workflows/relax/test_fleur.py
+++ b/tests/workflows/relax/test_fleur.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.fleur` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.fleur')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,22 +16,12 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('fleur.fleur').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             },
             'inpgen': {
                 'code': generate_code('fleur.inpgen').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
-            }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
+            },
         },
     }
 

--- a/tests/workflows/relax/test_gaussian.py
+++ b/tests/workflows/relax/test_gaussian.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.gaussian` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.gaussian')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,12 +16,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('gaussian').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }

--- a/tests/workflows/relax/test_implementations.py
+++ b/tests/workflows/relax/test_implementations.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, orm, plugins
+
 import pytest
+from aiida import engine, orm, plugins
 
 from aiida_common_workflows.common.types import ElectronicType, RelaxType, SpinType
 from aiida_common_workflows.generators.ports import InputGeneratorPort
@@ -22,34 +22,16 @@ def test_spec(workchain):
     generator_spec = generator.spec()
 
     required_ports = {
-        'structure': {
-            'valid_type': plugins.DataFactory('core.structure')
-        },
-        'protocol': {
-            'valid_type': str
-        },
-        'spin_type': {
-            'valid_type': SpinType
-        },
-        'relax_type': {
-            'valid_type': RelaxType
-        },
-        'electronic_type': {
-            'valid_type': ElectronicType
-        },
-        'magnetization_per_site': {
-            'valid_type': list
-        },
-        'threshold_forces': {
-            'valid_type': float
-        },
-        'threshold_stress': {
-            'valid_type': float
-        },
-        'reference_workchain': {
-            'valid_type': orm.WorkChainNode
-        },
-        'engines': {}
+        'structure': {'valid_type': plugins.DataFactory('core.structure')},
+        'protocol': {'valid_type': str},
+        'spin_type': {'valid_type': SpinType},
+        'relax_type': {'valid_type': RelaxType},
+        'electronic_type': {'valid_type': ElectronicType},
+        'magnetization_per_site': {'valid_type': list},
+        'threshold_forces': {'valid_type': float},
+        'threshold_stress': {'valid_type': float},
+        'reference_workchain': {'valid_type': orm.WorkChainNode},
+        'engines': {},
     }
 
     for port_name, values in required_ports.items():

--- a/tests/workflows/relax/test_nwchem.py
+++ b/tests/workflows/relax/test_nwchem.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.nwchem` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.nwchem')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,12 +16,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('nwchem.nwchem').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }

--- a/tests/workflows/relax/test_orca.py
+++ b/tests/workflows/relax/test_orca.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.orca` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.orca')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,12 +16,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('orca_main').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }

--- a/tests/workflows/relax/test_quantum_espresso.py
+++ b/tests/workflows/relax/test_quantum_espresso.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.quantum_espresso` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 from qe_tools import CONSTANTS
 
 from aiida_common_workflows.workflows.relax.generator import ElectronicType, RelaxType, SpinType
@@ -19,12 +19,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('quantumespresso.pw').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }
@@ -211,6 +206,6 @@ def test_magnetization_per_site(generate_code, generate_structure):
         structure=structure,
         engines=engines,
         magnetization_per_site=magnetization_per_site,
-        spin_type=SpinType.COLLINEAR
+        spin_type=SpinType.COLLINEAR,
     )
     assert builder['base']['pw']['parameters']['SYSTEM']['starting_magnetization'] == {'Si': 0.0, 'Ge': 0.025}

--- a/tests/workflows/relax/test_siesta.py
+++ b/tests/workflows/relax/test_siesta.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.siesta` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.siesta')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,13 +16,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('siesta.siesta').store().uuid,
-                'options': {
-                    'max_wallclock_seconds': 3600,
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'max_wallclock_seconds': 3600, 'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }

--- a/tests/workflows/relax/test_vasp.py
+++ b/tests/workflows/relax/test_vasp.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.vasp` module."""
-# pylint: disable=redefined-outer-name
-from aiida import engine, plugins
+
 import pytest
+from aiida import engine, plugins
 
 WORKCHAIN = plugins.WorkflowFactory('common_workflows.relax.vasp')
 GENERATOR = WORKCHAIN.get_input_generator()
@@ -16,12 +16,7 @@ def default_builder_inputs(generate_code, generate_structure):
         'engines': {
             'relax': {
                 'code': generate_code('vasp.vasp').store().uuid,
-                'options': {
-                    'resources': {
-                        'num_machines': 1,
-                        'tot_num_mpiprocs': 1
-                    }
-                }
+                'options': {'resources': {'num_machines': 1, 'tot_num_mpiprocs': 1}},
             }
         },
     }

--- a/tests/workflows/relax/test_workchain.py
+++ b/tests/workflows/relax/test_workchain.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=abstract-method,arguments-differ,redefined-outer-name
+
 """Tests for the :mod:`aiida_common_workflows.workflows.relax.workchain` module."""
-from aiida.plugins import WorkflowFactory
 import pytest
+from aiida.plugins import WorkflowFactory
 
 from aiida_common_workflows.plugins import get_workflow_entry_point_names
 from aiida_common_workflows.workflows.relax import CommonRelaxInputGenerator


### PR DESCRIPTION
`ruff` replaces `yapf`, `isort` and `pylint` as it is much faster than all these three tools combined.