### PR TITLE
Use `ProcessBuilder._merge` instead of `ProcessBuilder._update`

### DIFF
--- a/src/aiida_common_workflows/workflows/dissociation.py
+++ b/src/aiida_common_workflows/workflows/dissociation.py
@@ -170,7 +170,7 @@ class DissociationCurveWorkChain(WorkChain):
         builder = process_class.get_input_generator().get_builder(
             structure=molecule, reference_workchain=reference_workchain, **self.inputs.generator_inputs
         )
-        builder._update(**self.inputs.get('sub_process', {}))
+        builder._merge(**self.inputs.get('sub_process', {}))
 
         distance_node = molecule.creator.inputs.distance
 

--- a/src/aiida_common_workflows/workflows/eos.py
+++ b/src/aiida_common_workflows/workflows/eos.py
@@ -144,7 +144,7 @@ class EquationOfStateWorkChain(WorkChain):
             base_inputs['reference_workchain'] = reference_workchain
 
         builder = process_class.get_input_generator().get_builder(**base_inputs, **self.inputs.generator_inputs)
-        builder._update(**self.inputs.get('sub_process', {}))
+        builder._merge(**self.inputs.get('sub_process', {}))
 
         return builder, structure
 

--- a/src/aiida_common_workflows/workflows/relax/abinit/generator.py
+++ b/src/aiida_common_workflows/workflows/relax/abinit/generator.py
@@ -154,7 +154,7 @@ class AbinitCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         else:
             inputs = generate_inputs(self.process_class._process_class, protocol, code, structure, override)
 
-        builder._update(inputs)
+        builder._merge(inputs)
 
         # RelaxType
         if relax_type == RelaxType.NONE:

--- a/src/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/src/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -202,7 +202,7 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             inputs['calc']['kpoints'] = previous_kpoints
             inputs['base'].pop('kpoints_spacing', None)
 
-        builder._update(inputs)
+        builder._merge(inputs)
 
         return builder
 

--- a/src/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/src/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -201,7 +201,7 @@ class FleurCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             'wf_parameters': wf_para,
         }
 
-        builder._update(inputs)
+        builder._merge(inputs)
 
         return builder
 


### PR DESCRIPTION
Fixes #206 

The `ProcessBuilder._update` method does not properly recurse into nested mapping like `ProcessBuilder._merge` does. Note that the recursiveness just considers normal Python mappings and will not recurse inside node instances that may behave like mappings, such as `Dict` nodes.