### PR TITLE
Fix: Set common inputs to `non_db`

### DIFF
--- a/src/aiida_common_workflows/cli/options.py
+++ b/src/aiida_common_workflows/cli/options.py
@@ -107,7 +107,7 @@ class StructureDataParamType(click.Choice):
 
         duplicate = (
             QueryBuilder()
-            .append(StructureData, filters={'extras._aiida_hash': structure.base.caching._get_hash()})
+            .append(StructureData, filters={'extras._aiida_hash': structure.base.caching._compute_hash()})
             .first()
         )
 

--- a/src/aiida_common_workflows/workflows/bands/generator.py
+++ b/src/aiida_common_workflows/workflows/bands/generator.py
@@ -52,6 +52,7 @@ class CommonBandsInputGenerator(InputGenerator, metaclass=abc.ABCMeta):
         spec.input(
             'engines.bands.options',
             valid_type=dict,
+            non_db=True,
             required=False,
             help='Options for the bands calculation jobs.',
         )

--- a/src/aiida_common_workflows/workflows/relax/castep/generator.py
+++ b/src/aiida_common_workflows/workflows/relax/castep/generator.py
@@ -46,12 +46,8 @@ class CastepCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
         """
         super().define(spec)
-        spec.input(
-            'protocol',
-            valid_type=ChoiceType(('fast', 'moderate', 'precise', 'verification-PBE-v1', 'verification-PBE-v1-a0')),
-            default='moderate',
-            help='The protocol to use for the automated input generation. This value indicates the level of precision '
-            'of the results and computational cost that the input parameters will be selected for.',
+        spec.inputs['protocol'].valid_type = ChoiceType(
+            ('fast', 'moderate', 'precise', 'verification-PBE-v1', 'verification-PBE-v1-a0')
         )
         spec.inputs['spin_type'].valid_type = ChoiceType((SpinType.NONE, SpinType.COLLINEAR, SpinType.NON_COLLINEAR))
         spec.inputs['relax_type'].valid_type = ChoiceType(tuple(RelaxType))

--- a/src/aiida_common_workflows/workflows/relax/cp2k/generator.py
+++ b/src/aiida_common_workflows/workflows/relax/cp2k/generator.py
@@ -157,12 +157,8 @@ class Cp2kCommonRelaxInputGenerator(CommonRelaxInputGenerator):
         The ports defined on the specification are the inputs that will be accepted by the ``get_builder`` method.
         """
         super().define(spec)
-        spec.input(
-            'protocol',
-            valid_type=ChoiceType(('fast', 'moderate', 'precise', 'verification-PBE-v1', 'verification-PBE-v1-sirius')),
-            default='moderate',
-            help='The protocol to use for the automated input generation. This value indicates the level of precision '
-            'of the results and computational cost that the input parameters will be selected for.',
+        spec.inputs['protocol'].valid_type = ChoiceType(
+            ('fast', 'moderate', 'precise', 'verification-PBE-v1', 'verification-PBE-v1-sirius')
         )
         spec.inputs['spin_type'].valid_type = ChoiceType((SpinType.NONE, SpinType.COLLINEAR))
         spec.inputs['relax_type'].valid_type = ChoiceType(

--- a/src/aiida_common_workflows/workflows/relax/fleur/generator.py
+++ b/src/aiida_common_workflows/workflows/relax/fleur/generator.py
@@ -57,7 +57,7 @@ class FleurCommonRelaxInputGenerator(CommonRelaxInputGenerator):
             ('fast', 'moderate', 'precise', 'oxides_validation', 'verification-PBE-v1')
         )
         spec.input('engines.inpgen.code', valid_type=orm.Code, serializer=orm.load_code)
-        spec.input('engines.inpgen.options', valid_type=dict, required=False)
+        spec.input('engines.inpgen.options', non_db=True, valid_type=dict, required=False)
         spec.inputs['engines']['relax']['code'].valid_type = CodeType('fleur.fleur')
         spec.inputs['engines']['inpgen']['code'].valid_type = CodeType('fleur.inpgen')
 

--- a/src/aiida_common_workflows/workflows/relax/generator.py
+++ b/src/aiida_common_workflows/workflows/relax/generator.py
@@ -33,6 +33,7 @@ class CommonRelaxInputGenerator(InputGenerator, ProtocolRegistry, metaclass=abc.
             'protocol',
             valid_type=ChoiceType(('fast', 'moderate', 'precise')),
             default='moderate',
+            non_db=True,
             help='The protocol to use for the automated input generation. This value indicates the level of precision '
             'of the results and computational cost that the input parameters will be selected for.',
         )
@@ -61,6 +62,7 @@ class CommonRelaxInputGenerator(InputGenerator, ProtocolRegistry, metaclass=abc.
             'magnetization_per_site',
             valid_type=list,
             required=False,
+            non_db=True,
             help='The initial magnetization of the system. Should be a list of floats, where each float represents the '
             'spin polarization in units of electrons, meaning the difference between spin up and spin down '
             'electrons, for the site. This also corresponds to the magnetization of the site in Bohr magnetons '
@@ -70,6 +72,7 @@ class CommonRelaxInputGenerator(InputGenerator, ProtocolRegistry, metaclass=abc.
             'threshold_forces',
             valid_type=float,
             required=False,
+            non_db=True,
             help='A real positive number indicating the target threshold for the forces in eV/Å. If not specified, '
             'the protocol specification will select an appropriate value.',
         )
@@ -77,12 +80,14 @@ class CommonRelaxInputGenerator(InputGenerator, ProtocolRegistry, metaclass=abc.
             'threshold_stress',
             valid_type=float,
             required=False,
+            non_db=True,
             help='A real positive number indicating the target threshold for the stress in eV/Å^3. If not specified, '
             'the protocol specification will select an appropriate value.',
         )
         spec.input(
             'reference_workchain',
             valid_type=orm.WorkChainNode,
+            non_db=True,
             required=False,
             help='The node of a previously completed process of the same type whose inputs should be taken into '
             'account when generating inputs. This is important for particular workflows where certain inputs have '
@@ -106,5 +111,6 @@ class CommonRelaxInputGenerator(InputGenerator, ProtocolRegistry, metaclass=abc.
             'engines.relax.options',
             valid_type=dict,
             required=False,
+            non_db=True,
             help='Options for the geometry optimization calculation jobs.',
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def generate_input_generator_cls():
 
                 if inputs_dict is not None:
                     for k, val in inputs_dict.items():
-                        spec.input(k, valid_type=val)
+                        spec.input(k, valid_type=val, non_db=True)
 
             def _construct_builder(self, **kwargs) -> engine.ProcessBuilder:
                 builder = self.process_class.get_builder()


### PR DESCRIPTION
After setting `to_aiida_type` as the default serializer in `aiida-core 2.6`, the common workflows would fail. The common inputs expect Pyhton data types instead of their corresponding AiiDA data types. Instead of adding the corresponding AiiDA data types as valid types, I set `non_db = True` for the common inputs, since the inputs were not stored in the database before, anyway.