### PR TITLE
Fix: Update FLEUR energy extraction

### DIFF
--- a/src/aiida_common_workflows/workflows/relax/fleur/workchain.py
+++ b/src/aiida_common_workflows/workflows/relax/fleur/workchain.py
@@ -23,7 +23,7 @@ def get_forces_from_trajectory(trajectory):
 @calcfunction
 def get_total_energy(parameters):
     """Calcfunction to get total energy from relax output"""
-    return orm.Float(parameters.base.attributes.get('energy'))
+    return orm.Float(parameters.base.attributes.get('last_energy'))
 
 
 @calcfunction


### PR DESCRIPTION
The name of the `energy` output was changed in `aiida-fleur` (https://github.com/JuDFTteam/aiida-fleur/commit/32c3cef2d7c43f0b10c38fbce7484bfeb170ef44). Adapting the `get_total_energy` for FLEUR to fix this issue.