### PR TITLE
Bump requires-python to >= 3.10 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = ['aiida', 'workflows']
 license = {file = 'LICENSE.txt'}
 name = 'aiida-common-workflows'
 readme = 'README.md'
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 
 [project.entry-points.'aiida.workflows']
 'common_workflows.bands.siesta' = 'aiida_common_workflows.workflows.bands.siesta.workchain:SiestaCommonBandsWorkChain'


### PR DESCRIPTION
Commit https://github.com/aiidateam/aiida-common-workflows/commit/dc3dbbef6ce852a57d150214d4fca50a65e6e2b4 dropped support for Python 3.9 due to the upgrade to aiida-vasp 5.0. However, this doesn't seem to have been done in the `pyproject.toml` as well, which causes certain package managers (such as `uv`) to complain that the project dependencies/requirements are unsatisfiable. This PR also bumps the minimum python version to 3.10 in the `pyproject.toml`.